### PR TITLE
using relative paths when importing fonts from google

### DIFF
--- a/css/AdminLTE.css
+++ b/css/AdminLTE.css
@@ -1,6 +1,6 @@
-@import url(http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,300italic,400italic,600italic);
+@import url(//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,300italic,400italic,600italic);
 
-@import url(http://fonts.googleapis.com/css?family=Kaushan+Script);
+@import url(//fonts.googleapis.com/css?family=Kaushan+Script);
 /*! 
  *   AdminLTE v1.2
  *   Author: AlmsaeedStudio.com

--- a/less/AdminLTE.less
+++ b/less/AdminLTE.less
@@ -6,8 +6,8 @@
 !*/
 
 //google fonts
-@import url(http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,300italic,400italic,600italic);
-@import url(http://fonts.googleapis.com/css?family=Kaushan+Script);
+@import url(//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,300italic,400italic,600italic);
+@import url(//fonts.googleapis.com/css?family=Kaushan+Script);
 
 //MISC
 //----


### PR DESCRIPTION
the imports cause an insecure warning when loaded from an ssl site so it's better if we get rid of the protocol and just use // to default to whatever protocol is being used
