### PR TITLE
prevent wrong link button font color

### DIFF
--- a/css/AdminLTE.css
+++ b/css/AdminLTE.css
@@ -1318,7 +1318,7 @@ body > .header .logo .icon {
   float: left;
   cursor: default;
 }
-.box .box-header a {
+.box .box-header a:not(.btn) {
   color: #444;
 }
 .box .box-header > .box-tools {


### PR DESCRIPTION
prevents link buttons to be always in a dark color when in a box header
