### PR TITLE
Fix timeline bug where vertical line covers elements in same .row

### DIFF
--- a/less/timeline.less
+++ b/less/timeline.less
@@ -4,6 +4,7 @@ Component: timeline
 */
 
 .timeline{
+    position: relative;
     margin: 0 0 30px 0;
     padding: 0;
     list-style: none;
@@ -16,7 +17,7 @@ Component: timeline
         bottom: 0;
         width: 5px;
         background: #ddd;
-        left: 45px;
+        left: 30px;
         border: 1px solid #eee;
         margin: 0;
         .border-radius(2px);        


### PR DESCRIPTION
First of all, thank you thank you THANK YOU for this amazing theme and for the liberal licensing. I'm in the process of reskinning my [church app](http://church.io) using it, and I am totally in love.

I found this issue with the timeline...

If you put a timeline in the same row with another element, then the vertical line covers up stuff. Example:

![screen shot 2014-05-25 at 10 44 37 pm](https://cloud.githubusercontent.com/assets/669/3078978/88c8aade-e488-11e3-9f02-4967e59b9fbd.png)

The solution to this is to set `.timeline { position: relative; }`, however that pushes the line over by 15px. Example:

![screen shot 2014-05-25 at 10 44 53 pm](https://cloud.githubusercontent.com/assets/669/3078980/9d72c5c8-e488-11e3-867d-f6ac9e455469.png)

Finally, the fix for that is to set `left: 30px` instead of `45px`. Final outcome:

![screen shot 2014-05-25 at 10 45 09 pm](https://cloud.githubusercontent.com/assets/669/3078985/b15f9a84-e488-11e3-848d-44905f811cf2.png)
