### PR TITLE
Don't apply iCheck plugin to checkboxes with 'simple' css class.

### DIFF
--- a/js/AdminLTE/app.js
+++ b/js/AdminLTE/app.js
@@ -129,7 +129,7 @@ $(function() {
      * iCheck plugin in.
      * You can find the documentation at http://fronteed.com/iCheck/
      */
-    $("input[type='checkbox'], input[type='radio']").iCheck({
+    $("input[type='checkbox']:not(.simple), input[type='radio']:not(.simple)").iCheck({
         checkboxClass: 'icheckbox_minimal',
         radioClass: 'iradio_minimal'
     });


### PR DESCRIPTION
I needed a way to do 'normal' checkboxes since the iCheck plugin can be slow on pages with lots of checkboxes. This allows me to apply css class 'simple' to any checkbox to keep iCheck from being applied.
