### PR TITLE
Account for (optional) footer in wrapper height calc.

### DIFF
--- a/js/AdminLTE/app.js
+++ b/js/AdminLTE/app.js
@@ -101,7 +101,7 @@ $(function() {
      **/
     function _fix() {
         //Get window height and the wrapper height
-        var height = $(window).height() - $("body > .header").height();
+        var height = $(window).height() - $("body > .header").height() - ($("body > .footer").outerHeight() || 0);
         $(".wrapper").css("min-height", height + "px");
         var content = $(".wrapper").height();
         //If the wrapper height is greater than the window


### PR DESCRIPTION
I have a footer on my page, so needed to remove that height from the wrapper calc.

The way this code is written, it should not affect normal pages where there is no footer.

This PR has questionable value for your template, I understand. Please close if you don't think it is useful for the project as a whole. I can continue to patch my version for my own needs. Thanks!
