### PR TITLE
Fix broken javascript links in empty.html

### DIFF
--- a/empty.html
+++ b/empty.html
@@ -409,9 +409,9 @@
         <!-- jQuery 2.0.2 -->
         <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.0.2/jquery.min.js"></script>
         <!-- Bootstrap -->
-        <script src="js/plugins/bootstrap.min.js" type="text/javascript"></script>
+        <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js" type="text/javascript"></script>
         <!-- AdminLTE App -->
-        <script src="js/plugins/AdminLTE/app.js" type="text/javascript"></script>
+        <script src="js/AdminLTE/app.js" type="text/javascript"></script>
 
     </body>
 </html>


### PR DESCRIPTION
Change Bootstrap's javascript to CDN (used to be missing).
Correct the app.js path.
