### PR TITLE
fix height of layout on window resize

### DIFF
--- a/dist/js/app.js
+++ b/dist/js/app.js
@@ -169,7 +169,7 @@ $.AdminLTE.layout = {
     var _this = this;
     _this.fix();
     _this.fixSidebar();
-    $(".wrapper").resize(function () {
+    $(window, ".wrapper").resize(function () {
       _this.fix();
       _this.fixSidebar();
     });


### PR DESCRIPTION
When page doesn't have enough content and you upscale window, layout wasn't response on this change.

![screenshot from 2015-02-05 13 27 28](https://cloud.githubusercontent.com/assets/2624462/6060592/19715d22-ad3f-11e4-9e23-bc33c8a88068.png)

