### PR TITLE
make entire breadcrumb item clickable

### DIFF
--- a/build/less/header.less
+++ b/build/less/header.less
@@ -149,6 +149,7 @@
     > li > a {
       color: #444;
       text-decoration: none;
+      display: inline-block;
       > .fa, > .glyphicon, > .ion {
         margin-right: 5px;
       }


### PR DESCRIPTION
Because of icon margin, "a" tag  must be a block element in Google Chrome