### PR TITLE
Fixed .js filename in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
   "main": [
     "index2.html",
     "dist/css/AdminLTE.css",
-    "dist/js/AdminLTE.js",
+    "dist/js/app.js",
     "build/less/AdminLTE.less"
   ],
   "keywords": [


### PR DESCRIPTION
Fixed bower.json to match the javascript file on /dist/js