### PR TITLE
Removed closing tag from input elements

### DIFF
--- a/documentation/build/include/components.html
+++ b/documentation/build/include/components.html
@@ -906,7 +906,7 @@
           <h3 class="box-title">Input</h3>
           <div class="box-tools pull-right">
             <div class="has-feedback">
-              <input type="text" class="form-control input-sm" placeholder="Search..."/>
+              <input type="text" class="form-control input-sm" placeholder="Search...">
               <span class="glyphicon glyphicon-search form-control-feedback text-muted"></span>
             </div>
           </div><!-- /.box-tools -->
@@ -1067,7 +1067,7 @@
         <div class="box-footer">
           <form action="#" method="post">
             <div class="input-group">
-              <input type="text" name="message" placeholder="Type Message ..." class="form-control"/>
+              <input type="text" name="message" placeholder="Type Message ..." class="form-control">
               <span class="input-group-btn">
                 <button type="button" class="btn btn-primary btn-flat">Send</button>
               </span>
@@ -1138,7 +1138,7 @@
         <div class="box-footer">
           <form action="#" method="post">
             <div class="input-group">
-              <input type="text" name="message" placeholder="Type Message ..." class="form-control"/>
+              <input type="text" name="message" placeholder="Type Message ..." class="form-control">
               <span class="input-group-btn">
                 <button type="button" class="btn btn-success btn-flat">Send</button>
               </span>
@@ -1209,7 +1209,7 @@
         <div class="box-footer">
           <form action="#" method="post">
             <div class="input-group">
-              <input type="text" name="message" placeholder="Type Message ..." class="form-control"/>
+              <input type="text" name="message" placeholder="Type Message ..." class="form-control">
               <span class="input-group-btn">
                 <button type="button" class="btn btn-warning btn-flat">Send</button>
               </span>
@@ -1280,7 +1280,7 @@
         <div class="box-footer">
           <form action="#" method="post">
             <div class="input-group">
-              <input type="text" name="message" placeholder="Type Message ..." class="form-control"/>
+              <input type="text" name="message" placeholder="Type Message ..." class="form-control">
               <span class="input-group-btn">
                 <button type="button" class="btn btn-danger btn-flat">Send</button>
               </span>
@@ -1428,7 +1428,7 @@
         <div class="box-footer">
           <form action="#" method="post">
             <div class="input-group">
-              <input type="text" name="message" placeholder="Type Message ..." class="form-control"/>
+              <input type="text" name="message" placeholder="Type Message ..." class="form-control">
               <span class="input-group-btn">
                 <button type="button" class="btn btn-primary btn-flat">Send</button>
               </span>
@@ -1499,7 +1499,7 @@
         <div class="box-footer">
           <form action="#" method="post">
             <div class="input-group">
-              <input type="text" name="message" placeholder="Type Message ..." class="form-control"/>
+              <input type="text" name="message" placeholder="Type Message ..." class="form-control">
               <span class="input-group-btn">
                 <button type="button" class="btn btn-info btn-flat">Send</button>
               </span>

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -1277,7 +1277,7 @@ AdminLTE/
           <h3 class="box-title">Input</h3>
           <div class="box-tools pull-right">
             <div class="has-feedback">
-              <input type="text" class="form-control input-sm" placeholder="Search..."/>
+              <input type="text" class="form-control input-sm" placeholder="Search...">
               <span class="glyphicon glyphicon-search form-control-feedback text-muted"></span>
             </div>
           </div><!-- /.box-tools -->
@@ -1438,7 +1438,7 @@ AdminLTE/
         <div class="box-footer">
           <form action="#" method="post">
             <div class="input-group">
-              <input type="text" name="message" placeholder="Type Message ..." class="form-control"/>
+              <input type="text" name="message" placeholder="Type Message ..." class="form-control">
               <span class="input-group-btn">
                 <button type="button" class="btn btn-primary btn-flat">Send</button>
               </span>
@@ -1509,7 +1509,7 @@ AdminLTE/
         <div class="box-footer">
           <form action="#" method="post">
             <div class="input-group">
-              <input type="text" name="message" placeholder="Type Message ..." class="form-control"/>
+              <input type="text" name="message" placeholder="Type Message ..." class="form-control">
               <span class="input-group-btn">
                 <button type="button" class="btn btn-success btn-flat">Send</button>
               </span>
@@ -1580,7 +1580,7 @@ AdminLTE/
         <div class="box-footer">
           <form action="#" method="post">
             <div class="input-group">
-              <input type="text" name="message" placeholder="Type Message ..." class="form-control"/>
+              <input type="text" name="message" placeholder="Type Message ..." class="form-control">
               <span class="input-group-btn">
                 <button type="button" class="btn btn-warning btn-flat">Send</button>
               </span>
@@ -1651,7 +1651,7 @@ AdminLTE/
         <div class="box-footer">
           <form action="#" method="post">
             <div class="input-group">
-              <input type="text" name="message" placeholder="Type Message ..." class="form-control"/>
+              <input type="text" name="message" placeholder="Type Message ..." class="form-control">
               <span class="input-group-btn">
                 <button type="button" class="btn btn-danger btn-flat">Send</button>
               </span>
@@ -1799,7 +1799,7 @@ AdminLTE/
         <div class="box-footer">
           <form action="#" method="post">
             <div class="input-group">
-              <input type="text" name="message" placeholder="Type Message ..." class="form-control"/>
+              <input type="text" name="message" placeholder="Type Message ..." class="form-control">
               <span class="input-group-btn">
                 <button type="button" class="btn btn-primary btn-flat">Send</button>
               </span>
@@ -1870,7 +1870,7 @@ AdminLTE/
         <div class="box-footer">
           <form action="#" method="post">
             <div class="input-group">
-              <input type="text" name="message" placeholder="Type Message ..." class="form-control"/>
+              <input type="text" name="message" placeholder="Type Message ..." class="form-control">
               <span class="input-group-btn">
                 <button type="button" class="btn btn-info btn-flat">Send</button>
               </span>

--- a/index.html
+++ b/index.html
@@ -306,7 +306,7 @@
           <!-- search form -->
           <form action="#" method="get" class="sidebar-form">
             <div class="input-group">
-              <input type="text" name="q" class="form-control" placeholder="Search..."/>
+              <input type="text" name="q" class="form-control" placeholder="Search...">
               <span class="input-group-btn">
                 <button type='submit' name='search' id='search-btn' class="btn btn-flat"><i class="fa fa-search"></i></button>
               </span>
@@ -606,7 +606,7 @@
                 </div><!-- /.chat -->
                 <div class="box-footer">
                   <div class="input-group">
-                    <input class="form-control" placeholder="Type message..."/>
+                    <input class="form-control" placeholder="Type message...">
                     <div class="input-group-btn">
                       <button class="btn btn-success"><i class="fa fa-plus"></i></button>
                     </div>
@@ -638,7 +638,7 @@
                         <i class="fa fa-ellipsis-v"></i>
                       </span>
                       <!-- checkbox -->
-                      <input type="checkbox" value="" name=""/>
+                      <input type="checkbox" value="" name="">
                       <!-- todo text -->
                       <span class="text">Design a nice theme</span>
                       <!-- Emphasis label -->
@@ -654,7 +654,7 @@
                         <i class="fa fa-ellipsis-v"></i>
                         <i class="fa fa-ellipsis-v"></i>
                       </span>
-                      <input type="checkbox" value="" name=""/>
+                      <input type="checkbox" value="" name="">
                       <span class="text">Make the theme responsive</span>
                       <small class="label label-info"><i class="fa fa-clock-o"></i> 4 hours</small>
                       <div class="tools">
@@ -667,7 +667,7 @@
                         <i class="fa fa-ellipsis-v"></i>
                         <i class="fa fa-ellipsis-v"></i>
                       </span>
-                      <input type="checkbox" value="" name=""/>
+                      <input type="checkbox" value="" name="">
                       <span class="text">Let theme shine like a star</span>
                       <small class="label label-warning"><i class="fa fa-clock-o"></i> 1 day</small>
                       <div class="tools">
@@ -680,7 +680,7 @@
                         <i class="fa fa-ellipsis-v"></i>
                         <i class="fa fa-ellipsis-v"></i>
                       </span>
-                      <input type="checkbox" value="" name=""/>
+                      <input type="checkbox" value="" name="">
                       <span class="text">Let theme shine like a star</span>
                       <small class="label label-success"><i class="fa fa-clock-o"></i> 3 days</small>
                       <div class="tools">
@@ -693,7 +693,7 @@
                         <i class="fa fa-ellipsis-v"></i>
                         <i class="fa fa-ellipsis-v"></i>
                       </span>
-                      <input type="checkbox" value="" name=""/>
+                      <input type="checkbox" value="" name="">
                       <span class="text">Check your messages and notifications</span>
                       <small class="label label-primary"><i class="fa fa-clock-o"></i> 1 week</small>
                       <div class="tools">
@@ -706,7 +706,7 @@
                         <i class="fa fa-ellipsis-v"></i>
                         <i class="fa fa-ellipsis-v"></i>
                       </span>
-                      <input type="checkbox" value="" name=""/>
+                      <input type="checkbox" value="" name="">
                       <span class="text">Let theme shine like a star</span>
                       <small class="label label-default"><i class="fa fa-clock-o"></i> 1 month</small>
                       <div class="tools">
@@ -734,10 +734,10 @@
                 <div class="box-body">
                   <form action="#" method="post">
                     <div class="form-group">
-                      <input type="email" class="form-control" name="emailto" placeholder="Email to:"/>
+                      <input type="email" class="form-control" name="emailto" placeholder="Email to:">
                     </div>
                     <div class="form-group">
-                      <input type="text" class="form-control" name="subject" placeholder="Subject"/>
+                      <input type="text" class="form-control" name="subject" placeholder="Subject">
                     </div>
                     <div>
                       <textarea class="textarea" placeholder="Message" style="width: 100%; height: 125px; font-size: 14px; line-height: 18px; border: 1px solid #dddddd; padding: 10px;"></textarea>
@@ -805,15 +805,15 @@
                 <div class="box-footer no-border">
                   <div class="row">
                     <div class="col-xs-4 text-center" style="border-right: 1px solid #f4f4f4">
-                      <input type="text" class="knob" data-readonly="true" value="20" data-width="60" data-height="60" data-fgColor="#39CCCC"/>
+                      <input type="text" class="knob" data-readonly="true" value="20" data-width="60" data-height="60" data-fgColor="#39CCCC">
                       <div class="knob-label">Mail-Orders</div>
                     </div><!-- ./col -->
                     <div class="col-xs-4 text-center" style="border-right: 1px solid #f4f4f4">
-                      <input type="text" class="knob" data-readonly="true" value="50" data-width="60" data-height="60" data-fgColor="#39CCCC"/>
+                      <input type="text" class="knob" data-readonly="true" value="50" data-width="60" data-height="60" data-fgColor="#39CCCC">
                       <div class="knob-label">Online</div>
                     </div><!-- ./col -->
                     <div class="col-xs-4 text-center">
-                      <input type="text" class="knob" data-readonly="true" value="30" data-width="60" data-height="60" data-fgColor="#39CCCC"/>
+                      <input type="text" class="knob" data-readonly="true" value="30" data-width="60" data-height="60" data-fgColor="#39CCCC">
                       <div class="knob-label">In-Store</div>
                     </div><!-- ./col -->
                   </div><!-- /.row -->
@@ -1008,7 +1008,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Report panel usage
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Some information about this general settings option
@@ -1018,7 +1018,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Allow mail redirect
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Other sets of options are available
@@ -1028,7 +1028,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Expose author name in posts
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Allow the user to show his name in blog posts
@@ -1040,14 +1040,14 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Show me as online
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>                
               </div><!-- /.form-group -->
 
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Turn off notifications
-                  <input type="checkbox" class="pull-right" />
+                  <input type="checkbox" class="pull-right">
                 </label>                
               </div><!-- /.form-group -->
 

--- a/index2.html
+++ b/index2.html
@@ -304,7 +304,7 @@
           <!-- search form -->
           <form action="#" method="get" class="sidebar-form">
             <div class="input-group">
-              <input type="text" name="q" class="form-control" placeholder="Search..."/>
+              <input type="text" name="q" class="form-control" placeholder="Search...">
               <span class="input-group-btn">
                 <button type='submit' name='search' id='search-btn' class="btn btn-flat"><i class="fa fa-search"></i></button>
               </span>
@@ -803,7 +803,7 @@
                     <div class="box-footer">
                       <form action="#" method="post">
                         <div class="input-group">
-                          <input type="text" name="message" placeholder="Type Message ..." class="form-control"/>
+                          <input type="text" name="message" placeholder="Type Message ..." class="form-control">
                           <span class="input-group-btn">
                             <button type="button" class="btn btn-warning btn-flat">Send</button>
                           </span>
@@ -1221,7 +1221,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Report panel usage
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Some information about this general settings option
@@ -1231,7 +1231,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Allow mail redirect
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Other sets of options are available
@@ -1241,7 +1241,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Expose author name in posts
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Allow the user to show his name in blog posts
@@ -1253,14 +1253,14 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Show me as online
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
               </div><!-- /.form-group -->
 
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Turn off notifications
-                  <input type="checkbox" class="pull-right" />
+                  <input type="checkbox" class="pull-right">
                 </label>
               </div><!-- /.form-group -->
 

--- a/pages/UI/buttons.html
+++ b/pages/UI/buttons.html
@@ -297,7 +297,7 @@
           <!-- search form -->
           <form action="#" method="get" class="sidebar-form">
             <div class="input-group">
-              <input type="text" name="q" class="form-control" placeholder="Search..."/>
+              <input type="text" name="q" class="form-control" placeholder="Search...">
               <span class="input-group-btn">
                 <button type='submit' name='search' id='search-btn' class="btn btn-flat"><i class="fa fa-search"></i></button>
               </span>
@@ -1441,7 +1441,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Report panel usage
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Some information about this general settings option
@@ -1451,7 +1451,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Allow mail redirect
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Other sets of options are available
@@ -1461,7 +1461,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Expose author name in posts
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Allow the user to show his name in blog posts
@@ -1473,14 +1473,14 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Show me as online
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
               </div><!-- /.form-group -->
 
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Turn off notifications
-                  <input type="checkbox" class="pull-right" />
+                  <input type="checkbox" class="pull-right">
                 </label>
               </div><!-- /.form-group -->
 

--- a/pages/UI/general.html
+++ b/pages/UI/general.html
@@ -325,7 +325,7 @@
           <!-- search form -->
           <form action="#" method="get" class="sidebar-form">
             <div class="input-group">
-              <input type="text" name="q" class="form-control" placeholder="Search..."/>
+              <input type="text" name="q" class="form-control" placeholder="Search...">
               <span class="input-group-btn">
                 <button type='submit' name='search' id='search-btn' class="btn btn-flat"><i class="fa fa-search"></i></button>
               </span>
@@ -1301,7 +1301,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Report panel usage
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Some information about this general settings option
@@ -1311,7 +1311,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Allow mail redirect
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Other sets of options are available
@@ -1321,7 +1321,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Expose author name in posts
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Allow the user to show his name in blog posts
@@ -1333,14 +1333,14 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Show me as online
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>                
               </div><!-- /.form-group -->
 
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Turn off notifications
-                  <input type="checkbox" class="pull-right" />
+                  <input type="checkbox" class="pull-right">
                 </label>                
               </div><!-- /.form-group -->
 

--- a/pages/UI/icons.html
+++ b/pages/UI/icons.html
@@ -343,7 +343,7 @@
           <!-- search form -->
           <form action="#" method="get" class="sidebar-form">
             <div class="input-group">
-              <input type="text" name="q" class="form-control" placeholder="Search..."/>
+              <input type="text" name="q" class="form-control" placeholder="Search...">
               <span class="input-group-btn">
                 <button type='submit' name='search' id='search-btn' class="btn btn-flat"><i class="fa fa-search"></i></button>
               </span>
@@ -2262,7 +2262,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Report panel usage
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Some information about this general settings option
@@ -2272,7 +2272,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Allow mail redirect
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Other sets of options are available
@@ -2282,7 +2282,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Expose author name in posts
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Allow the user to show his name in blog posts
@@ -2294,14 +2294,14 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Show me as online
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>                
               </div><!-- /.form-group -->
 
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Turn off notifications
-                  <input type="checkbox" class="pull-right" />
+                  <input type="checkbox" class="pull-right">
                 </label>                
               </div><!-- /.form-group -->
 

--- a/pages/UI/modals.html
+++ b/pages/UI/modals.html
@@ -307,7 +307,7 @@
           <!-- search form -->
           <form action="#" method="get" class="sidebar-form">
             <div class="input-group">
-              <input type="text" name="q" class="form-control" placeholder="Search..."/>
+              <input type="text" name="q" class="form-control" placeholder="Search...">
               <span class="input-group-btn">
                 <button type='submit' name='search' id='search-btn' class="btn btn-flat"><i class="fa fa-search"></i></button>
               </span>
@@ -708,7 +708,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Report panel usage
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Some information about this general settings option
@@ -718,7 +718,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Allow mail redirect
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Other sets of options are available
@@ -728,7 +728,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Expose author name in posts
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Allow the user to show his name in blog posts
@@ -740,14 +740,14 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Show me as online
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>                
               </div><!-- /.form-group -->
 
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Turn off notifications
-                  <input type="checkbox" class="pull-right" />
+                  <input type="checkbox" class="pull-right">
                 </label>                
               </div><!-- /.form-group -->
 

--- a/pages/UI/sliders.html
+++ b/pages/UI/sliders.html
@@ -303,7 +303,7 @@
           <!-- search form -->
           <form action="#" method="get" class="sidebar-form">
             <div class="input-group">
-              <input type="text" name="q" class="form-control" placeholder="Search..."/>
+              <input type="text" name="q" class="form-control" placeholder="Search...">
               <span class="input-group-btn">
                 <button type='submit' name='search' id='search-btn' class="btn btn-flat"><i class="fa fa-search"></i></button>
               </span>
@@ -475,24 +475,24 @@
                 <div class="box-body">
                   <div class="row margin">
                     <div class="col-sm-6">
-                      <input id="range_1" type="text" name="range_1" value="" />
+                      <input id="range_1" type="text" name="range_1" value="">
                     </div>
 
                     <div class="col-sm-6">
-                      <input id="range_2" type="text" name="range_2" value="1000;100000" data-type="double" data-step="500" data-postfix=" &euro;" data-from="30000" data-to="90000" data-hasgrid="true" />
+                      <input id="range_2" type="text" name="range_2" value="1000;100000" data-type="double" data-step="500" data-postfix=" &euro;" data-from="30000" data-to="90000" data-hasgrid="true">
                     </div>
                   </div>
                   <div class="row margin">
                     <div class="col-sm-6">
-                      <input id="range_5" type="text" name="range_5" value="" />
+                      <input id="range_5" type="text" name="range_5" value="">
                     </div>
                     <div class="col-sm-6">
-                      <input id="range_6" type="text" name="range_6" value="" />
+                      <input id="range_6" type="text" name="range_6" value="">
                     </div>
                   </div>
                   <div class="row margin">
                     <div class="col-sm-12">
-                      <input id="range_4" type="text" name="range_4" value="10000;100000" />
+                      <input id="range_4" type="text" name="range_4" value="10000;100000">
                     </div>
                   </div>
                 </div><!-- /.box-body -->
@@ -654,7 +654,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Report panel usage
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Some information about this general settings option
@@ -664,7 +664,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Allow mail redirect
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Other sets of options are available
@@ -674,7 +674,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Expose author name in posts
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Allow the user to show his name in blog posts
@@ -686,14 +686,14 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Show me as online
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>                
               </div><!-- /.form-group -->
 
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Turn off notifications
-                  <input type="checkbox" class="pull-right" />
+                  <input type="checkbox" class="pull-right">
                 </label>                
               </div><!-- /.form-group -->
 

--- a/pages/UI/timeline.html
+++ b/pages/UI/timeline.html
@@ -297,7 +297,7 @@
           <!-- search form -->
           <form action="#" method="get" class="sidebar-form">
             <div class="input-group">
-              <input type="text" name="q" class="form-control" placeholder="Search..."/>
+              <input type="text" name="q" class="form-control" placeholder="Search...">
               <span class="input-group-btn">
                 <button type='submit' name='search' id='search-btn' class="btn btn-flat"><i class="fa fa-search"></i></button>
               </span>
@@ -731,7 +731,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Report panel usage
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Some information about this general settings option
@@ -741,7 +741,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Allow mail redirect
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Other sets of options are available
@@ -751,7 +751,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Expose author name in posts
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Allow the user to show his name in blog posts
@@ -763,14 +763,14 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Show me as online
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>                
               </div><!-- /.form-group -->
 
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Turn off notifications
-                  <input type="checkbox" class="pull-right" />
+                  <input type="checkbox" class="pull-right">
                 </label>                
               </div><!-- /.form-group -->
 

--- a/pages/calendar.html
+++ b/pages/calendar.html
@@ -296,7 +296,7 @@
           <!-- search form -->
           <form action="#" method="get" class="sidebar-form">
             <div class="input-group">
-              <input type="text" name="q" class="form-control" placeholder="Search..."/>
+              <input type="text" name="q" class="form-control" placeholder="Search...">
               <span class="input-group-btn">
                 <button type='submit' name='search' id='search-btn' class="btn btn-flat"><i class="fa fa-search"></i></button>
               </span>
@@ -474,7 +474,7 @@
                     <div class='external-event bg-red'>Sleep tight</div>
                     <div class="checkbox">
                       <label for='drop-remove'>
-                        <input type='checkbox' id='drop-remove' />
+                        <input type='checkbox' id='drop-remove'>
                         remove after drop
                       </label>
                     </div>
@@ -641,7 +641,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Report panel usage
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Some information about this general settings option
@@ -651,7 +651,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Allow mail redirect
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Other sets of options are available
@@ -661,7 +661,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Expose author name in posts
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Allow the user to show his name in blog posts
@@ -673,14 +673,14 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Show me as online
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>                
               </div><!-- /.form-group -->
 
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Turn off notifications
-                  <input type="checkbox" class="pull-right" />
+                  <input type="checkbox" class="pull-right">
                 </label>                
               </div><!-- /.form-group -->
 

--- a/pages/charts/chartjs.html
+++ b/pages/charts/chartjs.html
@@ -189,7 +189,7 @@
           <!-- search form -->
           <form action="#" method="get" class="sidebar-form">
             <div class="input-group">
-              <input type="text" name="q" class="form-control" placeholder="Search..."/>
+              <input type="text" name="q" class="form-control" placeholder="Search...">
               <span class="input-group-btn">
                 <button type='submit' name='search' id='search-btn' class="btn btn-flat"><i class="fa fa-search"></i></button>
               </span>
@@ -540,7 +540,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Report panel usage
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Some information about this general settings option
@@ -550,7 +550,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Allow mail redirect
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Other sets of options are available
@@ -560,7 +560,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Expose author name in posts
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Allow the user to show his name in blog posts
@@ -572,14 +572,14 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Show me as online
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>                
               </div><!-- /.form-group -->
 
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Turn off notifications
-                  <input type="checkbox" class="pull-right" />
+                  <input type="checkbox" class="pull-right">
                 </label>                
               </div><!-- /.form-group -->
 

--- a/pages/charts/flot.html
+++ b/pages/charts/flot.html
@@ -297,7 +297,7 @@
           <!-- search form -->
           <form action="#" method="get" class="sidebar-form">
             <div class="input-group">
-              <input type="text" name="q" class="form-control" placeholder="Search..."/>
+              <input type="text" name="q" class="form-control" placeholder="Search...">
               <span class="input-group-btn">
                 <button type='submit' name='search' id='search-btn' class="btn btn-flat"><i class="fa fa-search"></i></button>
               </span>
@@ -668,7 +668,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Report panel usage
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Some information about this general settings option
@@ -678,7 +678,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Allow mail redirect
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Other sets of options are available
@@ -688,7 +688,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Expose author name in posts
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Allow the user to show his name in blog posts
@@ -700,14 +700,14 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Show me as online
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>                
               </div><!-- /.form-group -->
 
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Turn off notifications
-                  <input type="checkbox" class="pull-right" />
+                  <input type="checkbox" class="pull-right">
                 </label>                
               </div><!-- /.form-group -->
 

--- a/pages/charts/inline.html
+++ b/pages/charts/inline.html
@@ -297,7 +297,7 @@
           <!-- search form -->
           <form action="#" method="get" class="sidebar-form">
             <div class="input-group">
-              <input type="text" name="q" class="form-control" placeholder="Search..."/>
+              <input type="text" name="q" class="form-control" placeholder="Search...">
               <span class="input-group-btn">
                 <button type='submit' name='search' id='search-btn' class="btn btn-flat"><i class="fa fa-search"></i></button>
               </span>
@@ -476,30 +476,30 @@
                 <div class="box-body">
                   <div class="row">
                     <div class="col-md-3 col-sm-6 col-xs-6 text-center">
-                      <input type="text" class="knob" value="30" data-width="90" data-height="90" data-fgColor="#3c8dbc"/>
+                      <input type="text" class="knob" value="30" data-width="90" data-height="90" data-fgColor="#3c8dbc">
                       <div class="knob-label">New Visitors</div>
                     </div><!-- ./col -->
                     <div class="col-md-3 col-sm-6 col-xs-6 text-center">
-                      <input type="text" class="knob" value="70" data-width="90" data-height="90" data-fgColor="#f56954"/>
+                      <input type="text" class="knob" value="70" data-width="90" data-height="90" data-fgColor="#f56954">
                       <div class="knob-label">Bounce Rate</div>
                     </div><!-- ./col -->
                     <div class="col-md-3 col-sm-6 col-xs-6 text-center">
-                      <input type="text" class="knob" value="-80" data-min="-150" data-max="150" data-width="90" data-height="90" data-fgColor="#00a65a"/>
+                      <input type="text" class="knob" value="-80" data-min="-150" data-max="150" data-width="90" data-height="90" data-fgColor="#00a65a">
                       <div class="knob-label">Server Load</div>
                     </div><!-- ./col -->
                     <div class="col-md-3 col-sm-6 col-xs-6 text-center">
-                      <input type="text" class="knob" value="40" data-width="90" data-height="90" data-fgColor="#00c0ef"/>
+                      <input type="text" class="knob" value="40" data-width="90" data-height="90" data-fgColor="#00c0ef">
                       <div class="knob-label">Disk Space</div>
                     </div><!-- ./col -->
                   </div><!-- /.row -->
 
                   <div class="row">
                     <div class="col-xs-6 text-center">
-                      <input type="text" class="knob" value="90" data-width="90" data-height="90" data-fgColor="#932ab6"/>
+                      <input type="text" class="knob" value="90" data-width="90" data-height="90" data-fgColor="#932ab6">
                       <div class="knob-label">Bandwidth</div>
                     </div><!-- ./col -->
                     <div class="col-xs-6 text-center">
-                      <input type="text" class="knob" value="50" data-width="90" data-height="90" data-fgColor="#39CCCC"/>
+                      <input type="text" class="knob" value="50" data-width="90" data-height="90" data-fgColor="#39CCCC">
                       <div class="knob-label">CPU</div>
                     </div><!-- ./col -->
                   </div><!-- /.row -->
@@ -522,19 +522,19 @@
                 <div class="box-body">
                   <div class="row">
                     <div class="col-md-3 col-sm-6 col-xs-6 text-center">
-                      <input type="text" class="knob" value="30" data-width="90" data-height="90" data-fgColor="#3c8dbc" data-readonly="true"/>
+                      <input type="text" class="knob" value="30" data-width="90" data-height="90" data-fgColor="#3c8dbc" data-readonly="true">
                       <div class="knob-label">data-width="90"</div>
                     </div><!-- ./col -->
                     <div class="col-md-3 col-sm-6 col-xs-6 text-center">
-                      <input type="text" class="knob" value="30" data-width="120" data-height="120" data-fgColor="#f56954"/>
+                      <input type="text" class="knob" value="30" data-width="120" data-height="120" data-fgColor="#f56954">
                       <div class="knob-label">data-width="120"</div>
                     </div><!-- ./col -->
                     <div class="col-md-3 col-sm-6 col-xs-6 text-center">
-                      <input type="text" class="knob" value="30" data-thickness="0.1" data-width="90" data-height="90" data-fgColor="#00a65a"/>
+                      <input type="text" class="knob" value="30" data-thickness="0.1" data-width="90" data-height="90" data-fgColor="#00a65a">
                       <div class="knob-label">data-thickness="0.1"</div>
                     </div><!-- ./col -->
                     <div class="col-md-3 col-sm-6 col-xs-6 text-center">
-                      <input type="text" class="knob" data-thickness="0.2" data-angleArc="250" data-angleOffset="-125" value="30" data-width="120" data-height="120" data-fgColor="#00c0ef"/>
+                      <input type="text" class="knob" data-thickness="0.2" data-angleArc="250" data-angleOffset="-125" value="30" data-width="120" data-height="120" data-fgColor="#00c0ef">
                       <div class="knob-label">data-angleArc="250"</div>
                     </div><!-- ./col -->
                   </div><!-- /.row -->
@@ -557,19 +557,19 @@
                 <div class="box-body">
                   <div class="row">
                     <div class="col-md-3 col-sm-6 col-xs-6 text-center">
-                      <input type="text" class="knob" value="80" data-skin="tron"  data-thickness="0.2" data-width="90" data-height="90" data-fgColor="#3c8dbc" data-readonly="true"/>
+                      <input type="text" class="knob" value="80" data-skin="tron"  data-thickness="0.2" data-width="90" data-height="90" data-fgColor="#3c8dbc" data-readonly="true">
                       <div class="knob-label">data-width="90"</div>
                     </div><!-- ./col -->
                     <div class="col-md-3 col-sm-6 col-xs-6 text-center">
-                      <input type="text" class="knob" value="60" data-skin="tron" data-thickness="0.2" data-width="120" data-height="120" data-fgColor="#f56954"/>
+                      <input type="text" class="knob" value="60" data-skin="tron" data-thickness="0.2" data-width="120" data-height="120" data-fgColor="#f56954">
                       <div class="knob-label">data-width="120"</div>
                     </div><!-- ./col -->
                     <div class="col-md-3 col-sm-6 col-xs-6 text-center">
-                      <input type="text" class="knob" value="10" data-skin="tron" data-thickness="0.1" data-width="90" data-height="90" data-fgColor="#00a65a"/>
+                      <input type="text" class="knob" value="10" data-skin="tron" data-thickness="0.1" data-width="90" data-height="90" data-fgColor="#00a65a">
                       <div class="knob-label">data-thickness="0.1"</div>
                     </div><!-- ./col -->
                     <div class="col-md-3 col-sm-6 col-xs-6 text-center">
-                      <input type="text" class="knob" value="100" data-skin="tron" data-thickness="0.2" data-angleArc="250" data-angleOffset="-125" data-width="120" data-height="120" data-fgColor="#00c0ef"/>
+                      <input type="text" class="knob" value="100" data-skin="tron" data-thickness="0.2" data-angleArc="250" data-angleOffset="-125" data-width="120" data-height="120" data-fgColor="#00c0ef">
                       <div class="knob-label">data-angleArc="250"</div>
                     </div><!-- ./col -->
                   </div><!-- /.row -->
@@ -839,7 +839,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Report panel usage
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Some information about this general settings option
@@ -849,7 +849,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Allow mail redirect
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Other sets of options are available
@@ -859,7 +859,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Expose author name in posts
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Allow the user to show his name in blog posts
@@ -871,14 +871,14 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Show me as online
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>                
               </div><!-- /.form-group -->
 
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Turn off notifications
-                  <input type="checkbox" class="pull-right" />
+                  <input type="checkbox" class="pull-right">
                 </label>                
               </div><!-- /.form-group -->
 

--- a/pages/charts/morris.html
+++ b/pages/charts/morris.html
@@ -299,7 +299,7 @@
           <!-- search form -->
           <form action="#" method="get" class="sidebar-form">
             <div class="input-group">
-              <input type="text" name="q" class="form-control" placeholder="Search..."/>
+              <input type="text" name="q" class="form-control" placeholder="Search...">
               <span class="input-group-btn">
                 <button type='submit' name='search' id='search-btn' class="btn btn-flat"><i class="fa fa-search"></i></button>
               </span>
@@ -648,7 +648,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Report panel usage
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Some information about this general settings option
@@ -658,7 +658,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Allow mail redirect
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Other sets of options are available
@@ -668,7 +668,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Expose author name in posts
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Allow the user to show his name in blog posts
@@ -680,14 +680,14 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Show me as online
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>                
               </div><!-- /.form-group -->
 
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Turn off notifications
-                  <input type="checkbox" class="pull-right" />
+                  <input type="checkbox" class="pull-right">
                 </label>                
               </div><!-- /.form-group -->
 

--- a/pages/examples/404.html
+++ b/pages/examples/404.html
@@ -297,7 +297,7 @@
           <!-- search form -->
           <form action="#" method="get" class="sidebar-form">
             <div class="input-group">
-              <input type="text" name="q" class="form-control" placeholder="Search..."/>
+              <input type="text" name="q" class="form-control" placeholder="Search...">
               <span class="input-group-btn">
                 <button type='submit' name='search' id='search-btn' class="btn btn-flat"><i class="fa fa-search"></i></button>
               </span>
@@ -470,7 +470,7 @@
               </p>
               <form class='search-form'>
                 <div class='input-group'>
-                  <input type="text" name="search" class='form-control' placeholder="Search"/>
+                  <input type="text" name="search" class='form-control' placeholder="Search">
                   <div class="input-group-btn">
                     <button type="submit" name="submit" class="btn btn-warning btn-flat"><i class="fa fa-search"></i></button>
                   </div>
@@ -597,7 +597,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Report panel usage
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Some information about this general settings option
@@ -607,7 +607,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Allow mail redirect
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Other sets of options are available
@@ -617,7 +617,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Expose author name in posts
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Allow the user to show his name in blog posts
@@ -629,14 +629,14 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Show me as online
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>                
               </div><!-- /.form-group -->
 
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Turn off notifications
-                  <input type="checkbox" class="pull-right" />
+                  <input type="checkbox" class="pull-right">
                 </label>                
               </div><!-- /.form-group -->
 

--- a/pages/examples/500.html
+++ b/pages/examples/500.html
@@ -297,7 +297,7 @@
           <!-- search form -->
           <form action="#" method="get" class="sidebar-form">
             <div class="input-group">
-              <input type="text" name="q" class="form-control" placeholder="Search..."/>
+              <input type="text" name="q" class="form-control" placeholder="Search...">
               <span class="input-group-btn">
                 <button type='submit' name='search' id='search-btn' class="btn btn-flat"><i class="fa fa-search"></i></button>
               </span>
@@ -470,7 +470,7 @@
               </p>
               <form class='search-form'>
                 <div class='input-group'>
-                  <input type="text" name="search" class='form-control' placeholder="Search"/>
+                  <input type="text" name="search" class='form-control' placeholder="Search">
                   <div class="input-group-btn">
                     <button type="submit" name="submit" class="btn btn-danger btn-flat"><i class="fa fa-search"></i></button>
                   </div>
@@ -598,7 +598,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Report panel usage
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Some information about this general settings option
@@ -608,7 +608,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Allow mail redirect
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Other sets of options are available
@@ -618,7 +618,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Expose author name in posts
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Allow the user to show his name in blog posts
@@ -630,14 +630,14 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Show me as online
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>                
               </div><!-- /.form-group -->
 
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Turn off notifications
-                  <input type="checkbox" class="pull-right" />
+                  <input type="checkbox" class="pull-right">
                 </label>                
               </div><!-- /.form-group -->
 

--- a/pages/examples/blank.html
+++ b/pages/examples/blank.html
@@ -193,7 +193,7 @@
           <!-- search form -->
           <form action="#" method="get" class="sidebar-form">
             <div class="input-group">
-              <input type="text" name="q" class="form-control" placeholder="Search..."/>
+              <input type="text" name="q" class="form-control" placeholder="Search...">
               <span class="input-group-btn">
                 <button type='submit' name='search' id='search-btn' class="btn btn-flat"><i class="fa fa-search"></i></button>
               </span>
@@ -496,7 +496,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Report panel usage
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Some information about this general settings option
@@ -506,7 +506,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Allow mail redirect
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Other sets of options are available
@@ -516,7 +516,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Expose author name in posts
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Allow the user to show his name in blog posts
@@ -528,14 +528,14 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Show me as online
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>                
               </div><!-- /.form-group -->
 
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Turn off notifications
-                  <input type="checkbox" class="pull-right" />
+                  <input type="checkbox" class="pull-right">
                 </label>                
               </div><!-- /.form-group -->
 

--- a/pages/examples/invoice.html
+++ b/pages/examples/invoice.html
@@ -297,7 +297,7 @@
           <!-- search form -->
           <form action="#" method="get" class="sidebar-form">
             <div class="input-group">
-              <input type="text" name="q" class="form-control" placeholder="Search..."/>
+              <input type="text" name="q" class="form-control" placeholder="Search...">
               <span class="input-group-btn">
                 <button type='submit' name='search' id='search-btn' class="btn btn-flat"><i class="fa fa-search"></i></button>
               </span>
@@ -718,7 +718,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Report panel usage
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Some information about this general settings option
@@ -728,7 +728,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Allow mail redirect
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Other sets of options are available
@@ -738,7 +738,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Expose author name in posts
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Allow the user to show his name in blog posts
@@ -750,14 +750,14 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Show me as online
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>                
               </div><!-- /.form-group -->
 
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Turn off notifications
-                  <input type="checkbox" class="pull-right" />
+                  <input type="checkbox" class="pull-right">
                 </label>                
               </div><!-- /.form-group -->
 

--- a/pages/examples/lockscreen.html
+++ b/pages/examples/lockscreen.html
@@ -38,7 +38,7 @@
         <!-- lockscreen credentials (contains the form) -->
         <form class="lockscreen-credentials">
           <div class="input-group">
-            <input type="password" class="form-control" placeholder="password" />
+            <input type="password" class="form-control" placeholder="password">
             <div class="input-group-btn">
               <button class="btn"><i class="fa fa-arrow-right text-muted"></i></button>
             </div>

--- a/pages/examples/login.html
+++ b/pages/examples/login.html
@@ -29,11 +29,11 @@
         <p class="login-box-msg">Sign in to start your session</p>
         <form action="../../index2.html" method="post">
           <div class="form-group has-feedback">
-            <input type="text" class="form-control" placeholder="Email"/>
+            <input type="text" class="form-control" placeholder="Email">
             <span class="glyphicon glyphicon-envelope form-control-feedback"></span>
           </div>
           <div class="form-group has-feedback">
-            <input type="password" class="form-control" placeholder="Password"/>
+            <input type="password" class="form-control" placeholder="Password">
             <span class="glyphicon glyphicon-lock form-control-feedback"></span>
           </div>
           <div class="row">

--- a/pages/examples/register.html
+++ b/pages/examples/register.html
@@ -30,19 +30,19 @@
         <p class="login-box-msg">Register a new membership</p>
         <form action="../../index.html" method="post">
           <div class="form-group has-feedback">
-            <input type="text" class="form-control" placeholder="Full name"/>
+            <input type="text" class="form-control" placeholder="Full name">
             <span class="glyphicon glyphicon-user form-control-feedback"></span>
           </div>
           <div class="form-group has-feedback">
-            <input type="text" class="form-control" placeholder="Email"/>
+            <input type="text" class="form-control" placeholder="Email">
             <span class="glyphicon glyphicon-envelope form-control-feedback"></span>
           </div>
           <div class="form-group has-feedback">
-            <input type="password" class="form-control" placeholder="Password"/>
+            <input type="password" class="form-control" placeholder="Password">
             <span class="glyphicon glyphicon-lock form-control-feedback"></span>
           </div>
           <div class="form-group has-feedback">
-            <input type="password" class="form-control" placeholder="Retype password"/>
+            <input type="password" class="form-control" placeholder="Retype password">
             <span class="glyphicon glyphicon-log-in form-control-feedback"></span>
           </div>
           <div class="row">

--- a/pages/forms/advanced.html
+++ b/pages/forms/advanced.html
@@ -307,7 +307,7 @@
           <!-- search form -->
           <form action="#" method="get" class="sidebar-form">
             <div class="input-group">
-              <input type="text" name="q" class="form-control" placeholder="Search..."/>
+              <input type="text" name="q" class="form-control" placeholder="Search...">
               <span class="input-group-btn">
                 <button type='submit' name='search' id='search-btn' class="btn btn-flat"><i class="fa fa-search"></i></button>
               </span>
@@ -485,7 +485,7 @@
                       <div class="input-group-addon">
                         <i class="fa fa-calendar"></i>
                       </div>
-                      <input type="text" class="form-control" data-inputmask="'alias': 'dd/mm/yyyy'" data-mask/>
+                      <input type="text" class="form-control" data-inputmask="'alias': 'dd/mm/yyyy'" data-mask>
                     </div><!-- /.input group -->
                   </div><!-- /.form group -->
 
@@ -495,7 +495,7 @@
                       <div class="input-group-addon">
                         <i class="fa fa-calendar"></i>
                       </div>
-                      <input type="text" class="form-control" data-inputmask="'alias': 'mm/dd/yyyy'" data-mask/>
+                      <input type="text" class="form-control" data-inputmask="'alias': 'mm/dd/yyyy'" data-mask>
                     </div><!-- /.input group -->
                   </div><!-- /.form group -->
 
@@ -506,7 +506,7 @@
                       <div class="input-group-addon">
                         <i class="fa fa-phone"></i>
                       </div>
-                      <input type="text" class="form-control" data-inputmask='"mask": "(999) 999-9999"' data-mask/>
+                      <input type="text" class="form-control" data-inputmask='"mask": "(999) 999-9999"' data-mask>
                     </div><!-- /.input group -->
                   </div><!-- /.form group -->
 
@@ -517,7 +517,7 @@
                       <div class="input-group-addon">
                         <i class="fa fa-phone"></i>
                       </div>
-                      <input type="text" class="form-control" data-inputmask="'mask': ['999-999-9999 [x99999]', '+099 99 99 9999[9]-9999']" data-mask/>
+                      <input type="text" class="form-control" data-inputmask="'mask': ['999-999-9999 [x99999]', '+099 99 99 9999[9]-9999']" data-mask>
                     </div><!-- /.input group -->
                   </div><!-- /.form group -->
 
@@ -528,7 +528,7 @@
                       <div class="input-group-addon">
                         <i class="fa fa-laptop"></i>
                       </div>
-                      <input type="text" class="form-control" data-inputmask="'alias': 'ip'" data-mask/>
+                      <input type="text" class="form-control" data-inputmask="'alias': 'ip'" data-mask>
                     </div><!-- /.input group -->
                   </div><!-- /.form group -->
 
@@ -543,14 +543,14 @@
                   <!-- Color Picker -->
                   <div class="form-group">
                     <label>Color picker:</label>
-                    <input type="text" class="form-control my-colorpicker1"/>
+                    <input type="text" class="form-control my-colorpicker1">
                   </div><!-- /.form group -->
 
                   <!-- Color Picker -->
                   <div class="form-group">
                     <label>Color picker with addon:</label>
                     <div class="input-group my-colorpicker2">
-                      <input type="text" class="form-control"/>
+                      <input type="text" class="form-control">
                       <div class="input-group-addon">
                         <i></i>
                       </div>
@@ -562,7 +562,7 @@
                     <div class="form-group">
                       <label>Time picker:</label>
                       <div class="input-group">
-                        <input type="text" class="form-control timepicker"/>
+                        <input type="text" class="form-control timepicker">
                         <div class="input-group-addon">
                           <i class="fa fa-clock-o"></i>
                         </div>
@@ -586,7 +586,7 @@
                       <div class="input-group-addon">
                         <i class="fa fa-calendar"></i>
                       </div>
-                      <input type="text" class="form-control pull-right" id="reservation"/>
+                      <input type="text" class="form-control pull-right" id="reservation">
                     </div><!-- /.input group -->
                   </div><!-- /.form group -->
 
@@ -597,7 +597,7 @@
                       <div class="input-group-addon">
                         <i class="fa fa-clock-o"></i>
                       </div>
-                      <input type="text" class="form-control pull-right" id="reservationtime"/>
+                      <input type="text" class="form-control pull-right" id="reservationtime">
                     </div><!-- /.input group -->
                   </div><!-- /.form group -->
 
@@ -626,13 +626,13 @@
                   <!-- checkbox -->
                   <div class="form-group">
                     <label>
-                      <input type="checkbox" class="minimal" checked/>
+                      <input type="checkbox" class="minimal" checked>
                     </label>
                     <label>
-                      <input type="checkbox" class="minimal"/>
+                      <input type="checkbox" class="minimal">
                     </label>
                     <label>
-                      <input type="checkbox" class="minimal" disabled/>
+                      <input type="checkbox" class="minimal" disabled>
                       Minimal skin checkbox
                     </label>
                   </div>
@@ -640,13 +640,13 @@
                   <!-- radio -->
                   <div class="form-group">
                     <label>
-                      <input type="radio" name="r1" class="minimal" checked/>
+                      <input type="radio" name="r1" class="minimal" checked>
                     </label>
                     <label>
-                      <input type="radio" name="r1" class="minimal"/>
+                      <input type="radio" name="r1" class="minimal">
                     </label>
                     <label>
-                      <input type="radio" name="r1" class="minimal" disabled/>
+                      <input type="radio" name="r1" class="minimal" disabled>
                       Minimal skin radio
                     </label>
                   </div>
@@ -656,13 +656,13 @@
                   <!-- checkbox -->
                   <div class="form-group">
                     <label>
-                      <input type="checkbox" class="minimal-red" checked/>
+                      <input type="checkbox" class="minimal-red" checked>
                     </label>
                     <label>
-                      <input type="checkbox" class="minimal-red"/>
+                      <input type="checkbox" class="minimal-red">
                     </label>
                     <label>
-                      <input type="checkbox" class="minimal-red" disabled/>
+                      <input type="checkbox" class="minimal-red" disabled>
                       Minimal red skin checkbox
                     </label>
                   </div>
@@ -670,13 +670,13 @@
                   <!-- radio -->
                   <div class="form-group">
                     <label>
-                      <input type="radio" name="r2" class="minimal-red" checked/>
+                      <input type="radio" name="r2" class="minimal-red" checked>
                     </label>
                     <label>
-                      <input type="radio" name="r2" class="minimal-red"/>
+                      <input type="radio" name="r2" class="minimal-red">
                     </label>
                     <label>
-                      <input type="radio" name="r2" class="minimal-red" disabled/>
+                      <input type="radio" name="r2" class="minimal-red" disabled>
                       Minimal red skin radio
                     </label>
                   </div>
@@ -686,13 +686,13 @@
                   <!-- checkbox -->
                   <div class="form-group">
                     <label>
-                      <input type="checkbox" class="flat-red" checked/>
+                      <input type="checkbox" class="flat-red" checked>
                     </label>
                     <label>
-                      <input type="checkbox" class="flat-red"/>
+                      <input type="checkbox" class="flat-red">
                     </label>
                     <label>
-                      <input type="checkbox" class="flat-red" disabled/>
+                      <input type="checkbox" class="flat-red" disabled>
                       Flat green skin checkbox
                     </label>
                   </div>
@@ -700,13 +700,13 @@
                   <!-- radio -->
                   <div class="form-group">
                     <label>
-                      <input type="radio" name="r3" class="flat-red" checked/>
+                      <input type="radio" name="r3" class="flat-red" checked>
                     </label>
                     <label>
-                      <input type="radio" name="r3" class="flat-red"/>
+                      <input type="radio" name="r3" class="flat-red">
                     </label>
                     <label>
-                      <input type="radio" name="r3" class="flat-red" disabled/>
+                      <input type="radio" name="r3" class="flat-red" disabled>
                       Flat green skin radio
                     </label>
                   </div>
@@ -837,7 +837,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Report panel usage
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Some information about this general settings option
@@ -847,7 +847,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Allow mail redirect
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Other sets of options are available
@@ -857,7 +857,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Expose author name in posts
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Allow the user to show his name in blog posts
@@ -869,14 +869,14 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Show me as online
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>                
               </div><!-- /.form-group -->
 
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Turn off notifications
-                  <input type="checkbox" class="pull-right" />
+                  <input type="checkbox" class="pull-right">
                 </label>                
               </div><!-- /.form-group -->
 

--- a/pages/forms/editors.html
+++ b/pages/forms/editors.html
@@ -299,7 +299,7 @@
           <!-- search form -->
           <form action="#" method="get" class="sidebar-form">
             <div class="input-group">
-              <input type="text" name="q" class="form-control" placeholder="Search..."/>
+              <input type="text" name="q" class="form-control" placeholder="Search...">
               <span class="input-group-btn">
                 <button type='submit' name='search' id='search-btn' class="btn btn-flat"><i class="fa fa-search"></i></button>
               </span>
@@ -618,7 +618,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Report panel usage
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Some information about this general settings option
@@ -628,7 +628,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Allow mail redirect
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Other sets of options are available
@@ -638,7 +638,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Expose author name in posts
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Allow the user to show his name in blog posts
@@ -650,14 +650,14 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Show me as online
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
               </div><!-- /.form-group -->
 
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Turn off notifications
-                  <input type="checkbox" class="pull-right" />
+                  <input type="checkbox" class="pull-right">
                 </label>
               </div><!-- /.form-group -->
 

--- a/pages/forms/general.html
+++ b/pages/forms/general.html
@@ -297,7 +297,7 @@
           <!-- search form -->
           <form action="#" method="get" class="sidebar-form">
             <div class="input-group">
-              <input type="text" name="q" class="form-control" placeholder="Search..."/>
+              <input type="text" name="q" class="form-control" placeholder="Search...">
               <span class="input-group-btn">
                 <button type='submit' name='search' id='search-btn' class="btn btn-flat"><i class="fa fa-search"></i></button>
               </span>
@@ -634,11 +634,11 @@
                     <!-- text input -->
                     <div class="form-group">
                       <label>Text</label>
-                      <input type="text" class="form-control" placeholder="Enter ..."/>
+                      <input type="text" class="form-control" placeholder="Enter ...">
                     </div>
                     <div class="form-group">
                       <label>Text Disabled</label>
-                      <input type="text" class="form-control" placeholder="Enter ..." disabled/>
+                      <input type="text" class="form-control" placeholder="Enter ..." disabled>
                     </div>
 
                     <!-- textarea -->
@@ -654,36 +654,36 @@
                     <!-- input states -->
                     <div class="form-group has-success">
                       <label class="control-label" for="inputSuccess"><i class="fa fa-check"></i> Input with success</label>
-                      <input type="text" class="form-control" id="inputSuccess" placeholder="Enter ..."/>
+                      <input type="text" class="form-control" id="inputSuccess" placeholder="Enter ...">
                     </div>
                     <div class="form-group has-warning">
                       <label class="control-label" for="inputWarning"><i class="fa fa-bell-o"></i> Input with warning</label>
-                      <input type="text" class="form-control" id="inputWarning" placeholder="Enter ..."/>
+                      <input type="text" class="form-control" id="inputWarning" placeholder="Enter ...">
                     </div>
                     <div class="form-group has-error">
                       <label class="control-label" for="inputError"><i class="fa fa-times-circle-o"></i> Input with error</label>
-                      <input type="text" class="form-control" id="inputError" placeholder="Enter ..."/>
+                      <input type="text" class="form-control" id="inputError" placeholder="Enter ...">
                     </div>
 
                     <!-- checkbox -->
                     <div class="form-group">
                       <div class="checkbox">
                         <label>
-                          <input type="checkbox"/>
+                          <input type="checkbox">
                           Checkbox 1
                         </label>
                       </div>
 
                       <div class="checkbox">
                         <label>
-                          <input type="checkbox"/>
+                          <input type="checkbox">
                           Checkbox 2
                         </label>
                       </div>
 
                       <div class="checkbox">
                         <label>
-                          <input type="checkbox" disabled/>
+                          <input type="checkbox" disabled>
                           Checkbox disabled
                         </label>
                       </div>
@@ -705,7 +705,7 @@
                       </div>
                       <div class="radio">
                         <label>
-                          <input type="radio" name="optionsRadios" id="optionsRadios3" value="option3" disabled/>
+                          <input type="radio" name="optionsRadios" id="optionsRadios3" value="option3" disabled>
                           Option three is disabled
                         </label>
                       </div>
@@ -879,7 +879,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Report panel usage
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Some information about this general settings option
@@ -889,7 +889,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Allow mail redirect
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Other sets of options are available
@@ -899,7 +899,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Expose author name in posts
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Allow the user to show his name in blog posts
@@ -911,14 +911,14 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Show me as online
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>                
               </div><!-- /.form-group -->
 
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Turn off notifications
-                  <input type="checkbox" class="pull-right" />
+                  <input type="checkbox" class="pull-right">
                 </label>                
               </div><!-- /.form-group -->
 

--- a/pages/layout/boxed.html
+++ b/pages/layout/boxed.html
@@ -191,7 +191,7 @@
           <!-- search form -->
           <form action="#" method="get" class="sidebar-form">
             <div class="input-group">
-              <input type="text" name="q" class="form-control" placeholder="Search..."/>
+              <input type="text" name="q" class="form-control" placeholder="Search...">
               <span class="input-group-btn">
                 <button type='submit' name='search' id='search-btn' class="btn btn-flat"><i class="fa fa-search"></i></button>
               </span>
@@ -497,7 +497,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Report panel usage
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Some information about this general settings option
@@ -507,7 +507,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Allow mail redirect
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Other sets of options are available
@@ -517,7 +517,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Expose author name in posts
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Allow the user to show his name in blog posts
@@ -529,14 +529,14 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Show me as online
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>                
               </div><!-- /.form-group -->
 
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Turn off notifications
-                  <input type="checkbox" class="pull-right" />
+                  <input type="checkbox" class="pull-right">
                 </label>                
               </div><!-- /.form-group -->
 

--- a/pages/layout/collapsed-sidebar.html
+++ b/pages/layout/collapsed-sidebar.html
@@ -194,7 +194,7 @@
           <!-- search form -->
           <form action="#" method="get" class="sidebar-form">
             <div class="input-group">
-              <input type="text" name="q" class="form-control" placeholder="Search..."/>
+              <input type="text" name="q" class="form-control" placeholder="Search...">
               <span class="input-group-btn">
                 <button type='submit' name='search' id='search-btn' class="btn btn-flat"><i class="fa fa-search"></i></button>
               </span>
@@ -500,7 +500,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Report panel usage
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Some information about this general settings option
@@ -510,7 +510,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Allow mail redirect
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Other sets of options are available
@@ -520,7 +520,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Expose author name in posts
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Allow the user to show his name in blog posts
@@ -532,14 +532,14 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Show me as online
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
               </div><!-- /.form-group -->
 
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Turn off notifications
-                  <input type="checkbox" class="pull-right" />
+                  <input type="checkbox" class="pull-right">
                 </label>
               </div><!-- /.form-group -->
 

--- a/pages/layout/fixed.html
+++ b/pages/layout/fixed.html
@@ -195,7 +195,7 @@
           <!-- search form -->
           <form action="#" method="get" class="sidebar-form">
             <div class="input-group">
-              <input type="text" name="q" class="form-control" placeholder="Search..."/>
+              <input type="text" name="q" class="form-control" placeholder="Search...">
               <span class="input-group-btn">
                 <button type='submit' name='search' id='search-btn' class="btn btn-flat"><i class="fa fa-search"></i></button>
               </span>
@@ -501,7 +501,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Report panel usage
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Some information about this general settings option
@@ -511,7 +511,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Allow mail redirect
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Other sets of options are available
@@ -521,7 +521,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Expose author name in posts
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Allow the user to show his name in blog posts
@@ -533,14 +533,14 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Show me as online
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>                
               </div><!-- /.form-group -->
 
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Turn off notifications
-                  <input type="checkbox" class="pull-right" />
+                  <input type="checkbox" class="pull-right">
                 </label>                
               </div><!-- /.form-group -->
 

--- a/pages/layout/rtl.html
+++ b/pages/layout/rtl.html
@@ -194,7 +194,7 @@
           <!-- search form -->
           <form action="#" method="get" class="sidebar-form">
             <div class="input-group">
-              <input type="text" name="q" class="form-control" placeholder="Search..."/>
+              <input type="text" name="q" class="form-control" placeholder="Search...">
               <span class="input-group-btn">
                 <button type='submit' name='search' id='search-btn' class="btn btn-flat"><i class="fa fa-search"></i></button>
               </span>
@@ -500,7 +500,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Report panel usage
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Some information about this general settings option
@@ -510,7 +510,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Allow mail redirect
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Other sets of options are available
@@ -520,7 +520,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Expose author name in posts
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Allow the user to show his name in blog posts
@@ -532,14 +532,14 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Show me as online
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
               </div><!-- /.form-group -->
 
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Turn off notifications
-                  <input type="checkbox" class="pull-right" />
+                  <input type="checkbox" class="pull-right">
                 </label>
               </div><!-- /.form-group -->
 

--- a/pages/mailbox/compose.html
+++ b/pages/mailbox/compose.html
@@ -196,7 +196,7 @@
           <!-- search form -->
           <form action="#" method="get" class="sidebar-form">
             <div class="input-group">
-              <input type="text" name="q" class="form-control" placeholder="Search..."/>
+              <input type="text" name="q" class="form-control" placeholder="Search...">
               <span class="input-group-btn">
                 <button type='submit' name='search' id='search-btn' class="btn btn-flat"><i class="fa fa-search"></i></button>
               </span>
@@ -406,10 +406,10 @@
                 </div><!-- /.box-header -->
                 <div class="box-body">
                   <div class="form-group">
-                    <input class="form-control" placeholder="To:"/>
+                    <input class="form-control" placeholder="To:">
                   </div>
                   <div class="form-group">
-                    <input class="form-control" placeholder="Subject:"/>
+                    <input class="form-control" placeholder="Subject:">
                   </div>
                   <div class="form-group">
                     <textarea id="compose-textarea" class="form-control" style="height: 300px">
@@ -429,7 +429,7 @@
                   <div class="form-group">
                     <div class="btn btn-default btn-file">
                       <i class="fa fa-paperclip"></i> Attachment
-                      <input type="file" name="attachment"/>
+                      <input type="file" name="attachment">
                     </div>
                     <p class="help-block">Max. 32MB</p>
                   </div>
@@ -563,7 +563,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Report panel usage
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Some information about this general settings option
@@ -573,7 +573,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Allow mail redirect
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Other sets of options are available
@@ -583,7 +583,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Expose author name in posts
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Allow the user to show his name in blog posts
@@ -595,14 +595,14 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Show me as online
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>                
               </div><!-- /.form-group -->
 
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Turn off notifications
-                  <input type="checkbox" class="pull-right" />
+                  <input type="checkbox" class="pull-right">
                 </label>                
               </div><!-- /.form-group -->
 

--- a/pages/mailbox/mailbox.html
+++ b/pages/mailbox/mailbox.html
@@ -193,7 +193,7 @@
           <!-- search form -->
           <form action="#" method="get" class="sidebar-form">
             <div class="input-group">
-              <input type="text" name="q" class="form-control" placeholder="Search..."/>
+              <input type="text" name="q" class="form-control" placeholder="Search...">
               <span class="input-group-btn">
                 <button type='submit' name='search' id='search-btn' class="btn btn-flat"><i class="fa fa-search"></i></button>
               </span>
@@ -402,7 +402,7 @@
                   <h3 class="box-title">Inbox</h3>
                   <div class="box-tools pull-right">
                     <div class="has-feedback">
-                      <input type="text" class="form-control input-sm" placeholder="Search Mail"/>
+                      <input type="text" class="form-control input-sm" placeholder="Search Mail">
                       <span class="glyphicon glyphicon-search form-control-feedback"></span>
                     </div>
                   </div><!-- /.box-tools -->
@@ -429,7 +429,7 @@
                     <table class="table table-hover table-striped">
                       <tbody>
                         <tr>
-                          <td><input type="checkbox" /></td>
+                          <td><input type="checkbox"></td>
                           <td class="mailbox-star"><a href="#"><i class="fa fa-star text-yellow"></i></a></td>
                           <td class="mailbox-name"><a href="read-mail.html">Alexander Pierce</a></td>
                           <td class="mailbox-subject"><b>AdminLTE 2.0 Issue</b> - Trying to find a solution to this problem...</td>
@@ -437,7 +437,7 @@
                           <td class="mailbox-date">5 mins ago</td>
                         </tr>
                         <tr>
-                          <td><input type="checkbox" /></td>
+                          <td><input type="checkbox"></td>
                           <td class="mailbox-star"><a href="#"><i class="fa fa-star-o text-yellow"></i></a></td>
                           <td class="mailbox-name"><a href="read-mail.html">Alexander Pierce</a></td>
                           <td class="mailbox-subject"><b>AdminLTE 2.0 Issue</b> - Trying to find a solution to this problem...</td>
@@ -445,7 +445,7 @@
                           <td class="mailbox-date">28 mins ago</td>
                         </tr>
                         <tr>
-                          <td><input type="checkbox" /></td>
+                          <td><input type="checkbox"></td>
                           <td class="mailbox-star"><a href="#"><i class="fa fa-star-o text-yellow"></i></a></td>
                           <td class="mailbox-name"><a href="read-mail.html">Alexander Pierce</a></td>
                           <td class="mailbox-subject"><b>AdminLTE 2.0 Issue</b> - Trying to find a solution to this problem...</td>
@@ -453,7 +453,7 @@
                           <td class="mailbox-date">11 hours ago</td>
                         </tr>
                         <tr>
-                          <td><input type="checkbox" /></td>
+                          <td><input type="checkbox"></td>
                           <td class="mailbox-star"><a href="#"><i class="fa fa-star text-yellow"></i></a></td>
                           <td class="mailbox-name"><a href="read-mail.html">Alexander Pierce</a></td>
                           <td class="mailbox-subject"><b>AdminLTE 2.0 Issue</b> - Trying to find a solution to this problem...</td>
@@ -461,7 +461,7 @@
                           <td class="mailbox-date">15 hours ago</td>
                         </tr>
                         <tr>
-                          <td><input type="checkbox" /></td>
+                          <td><input type="checkbox"></td>
                           <td class="mailbox-star"><a href="#"><i class="fa fa-star text-yellow"></i></a></td>
                           <td class="mailbox-name"><a href="read-mail.html">Alexander Pierce</a></td>
                           <td class="mailbox-subject"><b>AdminLTE 2.0 Issue</b> - Trying to find a solution to this problem...</td>
@@ -469,7 +469,7 @@
                           <td class="mailbox-date">Yesterday</td>
                         </tr>
                         <tr>
-                          <td><input type="checkbox" /></td>
+                          <td><input type="checkbox"></td>
                           <td class="mailbox-star"><a href="#"><i class="fa fa-star-o text-yellow"></i></a></td>
                           <td class="mailbox-name"><a href="read-mail.html">Alexander Pierce</a></td>
                           <td class="mailbox-subject"><b>AdminLTE 2.0 Issue</b> - Trying to find a solution to this problem...</td>
@@ -477,7 +477,7 @@
                           <td class="mailbox-date">2 days ago</td>
                         </tr>
                         <tr>
-                          <td><input type="checkbox" /></td>
+                          <td><input type="checkbox"></td>
                           <td class="mailbox-star"><a href="#"><i class="fa fa-star-o text-yellow"></i></a></td>
                           <td class="mailbox-name"><a href="read-mail.html">Alexander Pierce</a></td>
                           <td class="mailbox-subject"><b>AdminLTE 2.0 Issue</b> - Trying to find a solution to this problem...</td>
@@ -485,7 +485,7 @@
                           <td class="mailbox-date">2 days ago</td>
                         </tr>
                         <tr>
-                          <td><input type="checkbox" /></td>
+                          <td><input type="checkbox"></td>
                           <td class="mailbox-star"><a href="#"><i class="fa fa-star text-yellow"></i></a></td>
                           <td class="mailbox-name"><a href="read-mail.html">Alexander Pierce</a></td>
                           <td class="mailbox-subject"><b>AdminLTE 2.0 Issue</b> - Trying to find a solution to this problem...</td>
@@ -493,7 +493,7 @@
                           <td class="mailbox-date">2 days ago</td>
                         </tr>
                         <tr>
-                          <td><input type="checkbox" /></td>
+                          <td><input type="checkbox"></td>
                           <td class="mailbox-star"><a href="#"><i class="fa fa-star text-yellow"></i></a></td>
                           <td class="mailbox-name"><a href="read-mail.html">Alexander Pierce</a></td>
                           <td class="mailbox-subject"><b>AdminLTE 2.0 Issue</b> - Trying to find a solution to this problem...</td>
@@ -501,7 +501,7 @@
                           <td class="mailbox-date">2 days ago</td>
                         </tr>
                         <tr>
-                          <td><input type="checkbox" /></td>
+                          <td><input type="checkbox"></td>
                           <td class="mailbox-star"><a href="#"><i class="fa fa-star-o text-yellow"></i></a></td>
                           <td class="mailbox-name"><a href="read-mail.html">Alexander Pierce</a></td>
                           <td class="mailbox-subject"><b>AdminLTE 2.0 Issue</b> - Trying to find a solution to this problem...</td>
@@ -509,7 +509,7 @@
                           <td class="mailbox-date">2 days ago</td>
                         </tr>
                         <tr>
-                          <td><input type="checkbox" /></td>
+                          <td><input type="checkbox"></td>
                           <td class="mailbox-star"><a href="#"><i class="fa fa-star-o text-yellow"></i></a></td>
                           <td class="mailbox-name"><a href="read-mail.html">Alexander Pierce</a></td>
                           <td class="mailbox-subject"><b>AdminLTE 2.0 Issue</b> - Trying to find a solution to this problem...</td>
@@ -517,7 +517,7 @@
                           <td class="mailbox-date">4 days ago</td>
                         </tr>
                         <tr>
-                          <td><input type="checkbox" /></td>
+                          <td><input type="checkbox"></td>
                           <td class="mailbox-star"><a href="#"><i class="fa fa-star text-yellow"></i></a></td>
                           <td class="mailbox-name"><a href="read-mail.html">Alexander Pierce</a></td>
                           <td class="mailbox-subject"><b>AdminLTE 2.0 Issue</b> - Trying to find a solution to this problem...</td>
@@ -525,7 +525,7 @@
                           <td class="mailbox-date">12 days ago</td>
                         </tr>
                         <tr>
-                          <td><input type="checkbox" /></td>
+                          <td><input type="checkbox"></td>
                           <td class="mailbox-star"><a href="#"><i class="fa fa-star-o text-yellow"></i></a></td>
                           <td class="mailbox-name"><a href="read-mail.html">Alexander Pierce</a></td>
                           <td class="mailbox-subject"><b>AdminLTE 2.0 Issue</b> - Trying to find a solution to this problem...</td>
@@ -533,7 +533,7 @@
                           <td class="mailbox-date">12 days ago</td>
                         </tr>
                         <tr>
-                          <td><input type="checkbox" /></td>
+                          <td><input type="checkbox"></td>
                           <td class="mailbox-star"><a href="#"><i class="fa fa-star text-yellow"></i></a></td>
                           <td class="mailbox-name"><a href="read-mail.html">Alexander Pierce</a></td>
                           <td class="mailbox-subject"><b>AdminLTE 2.0 Issue</b> - Trying to find a solution to this problem...</td>
@@ -541,7 +541,7 @@
                           <td class="mailbox-date">14 days ago</td>
                         </tr>
                         <tr>
-                          <td><input type="checkbox" /></td>
+                          <td><input type="checkbox"></td>
                           <td class="mailbox-star"><a href="#"><i class="fa fa-star text-yellow"></i></a></td>
                           <td class="mailbox-name"><a href="read-mail.html">Alexander Pierce</a></td>
                           <td class="mailbox-subject"><b>AdminLTE 2.0 Issue</b> - Trying to find a solution to this problem...</td>
@@ -693,7 +693,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Report panel usage
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Some information about this general settings option
@@ -703,7 +703,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Allow mail redirect
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Other sets of options are available
@@ -713,7 +713,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Expose author name in posts
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Allow the user to show his name in blog posts
@@ -725,14 +725,14 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Show me as online
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>                
               </div><!-- /.form-group -->
 
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Turn off notifications
-                  <input type="checkbox" class="pull-right" />
+                  <input type="checkbox" class="pull-right">
                 </label>                
               </div><!-- /.form-group -->
 

--- a/pages/mailbox/read-mail.html
+++ b/pages/mailbox/read-mail.html
@@ -193,7 +193,7 @@
           <!-- search form -->
           <form action="#" method="get" class="sidebar-form">
             <div class="input-group">
-              <input type="text" name="q" class="form-control" placeholder="Search..."/>
+              <input type="text" name="q" class="form-control" placeholder="Search...">
               <span class="input-group-btn">
                 <button type='submit' name='search' id='search-btn' class="btn btn-flat"><i class="fa fa-search"></i></button>
               </span>
@@ -599,7 +599,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Report panel usage
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Some information about this general settings option
@@ -609,7 +609,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Allow mail redirect
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Other sets of options are available
@@ -619,7 +619,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Expose author name in posts
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Allow the user to show his name in blog posts
@@ -631,14 +631,14 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Show me as online
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>                
               </div><!-- /.form-group -->
 
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Turn off notifications
-                  <input type="checkbox" class="pull-right" />
+                  <input type="checkbox" class="pull-right">
                 </label>                
               </div><!-- /.form-group -->
 

--- a/pages/tables/data.html
+++ b/pages/tables/data.html
@@ -299,7 +299,7 @@
           <!-- search form -->
           <form action="#" method="get" class="sidebar-form">
             <div class="input-group">
-              <input type="text" name="q" class="form-control" placeholder="Search..."/>
+              <input type="text" name="q" class="form-control" placeholder="Search...">
               <span class="input-group-btn">
                 <button type='submit' name='search' id='search-btn' class="btn btn-flat"><i class="fa fa-search"></i></button>
               </span>
@@ -1450,7 +1450,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Report panel usage
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Some information about this general settings option
@@ -1460,7 +1460,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Allow mail redirect
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Other sets of options are available
@@ -1470,7 +1470,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Expose author name in posts
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Allow the user to show his name in blog posts
@@ -1482,14 +1482,14 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Show me as online
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>                
               </div><!-- /.form-group -->
 
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Turn off notifications
-                  <input type="checkbox" class="pull-right" />
+                  <input type="checkbox" class="pull-right">
                 </label>                
               </div><!-- /.form-group -->
 

--- a/pages/tables/simple.html
+++ b/pages/tables/simple.html
@@ -297,7 +297,7 @@
           <!-- search form -->
           <form action="#" method="get" class="sidebar-form">
             <div class="input-group">
-              <input type="text" name="q" class="form-control" placeholder="Search..."/>
+              <input type="text" name="q" class="form-control" placeholder="Search...">
               <span class="input-group-btn">
                 <button type='submit' name='search' id='search-btn' class="btn btn-flat"><i class="fa fa-search"></i></button>
               </span>
@@ -713,7 +713,7 @@
                   <h3 class="box-title">Responsive Hover Table</h3>
                   <div class="box-tools">
                     <div class="input-group">
-                      <input type="text" name="table_search" class="form-control input-sm pull-right" style="width: 150px;" placeholder="Search"/>
+                      <input type="text" name="table_search" class="form-control input-sm pull-right" style="width: 150px;" placeholder="Search">
                       <div class="input-group-btn">
                         <button class="btn btn-sm btn-default"><i class="fa fa-search"></i></button>
                       </div>
@@ -881,7 +881,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Report panel usage
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Some information about this general settings option
@@ -891,7 +891,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Allow mail redirect
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Other sets of options are available
@@ -901,7 +901,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Expose author name in posts
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Allow the user to show his name in blog posts
@@ -913,14 +913,14 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Show me as online
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>                
               </div><!-- /.form-group -->
 
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Turn off notifications
-                  <input type="checkbox" class="pull-right" />
+                  <input type="checkbox" class="pull-right">
                 </label>                
               </div><!-- /.form-group -->
 

--- a/pages/widgets.html
+++ b/pages/widgets.html
@@ -297,7 +297,7 @@
           <!-- search form -->
           <form action="#" method="get" class="sidebar-form">
             <div class="input-group">
-              <input type="text" name="q" class="form-control" placeholder="Search..."/>
+              <input type="text" name="q" class="form-control" placeholder="Search...">
               <span class="input-group-btn">
                 <button type='submit' name='search' id='search-btn' class="btn btn-flat"><i class="fa fa-search"></i></button>
               </span>
@@ -813,7 +813,7 @@
                 <div class="box-footer">
                   <form action="#" method="post">
                     <div class="input-group">
-                      <input type="text" name="message" placeholder="Type Message ..." class="form-control"/>
+                      <input type="text" name="message" placeholder="Type Message ..." class="form-control">
                       <span class="input-group-btn">
                         <button type="button" class="btn btn-primary btn-flat">Send</button>
                       </span>
@@ -884,7 +884,7 @@
                 <div class="box-footer">
                   <form action="#" method="post">
                     <div class="input-group">
-                      <input type="text" name="message" placeholder="Type Message ..." class="form-control"/>
+                      <input type="text" name="message" placeholder="Type Message ..." class="form-control">
                       <span class="input-group-btn">
                         <button type="button" class="btn btn-success btn-flat">Send</button>
                       </span>
@@ -955,7 +955,7 @@
                 <div class="box-footer">
                   <form action="#" method="post">
                     <div class="input-group">
-                      <input type="text" name="message" placeholder="Type Message ..." class="form-control"/>
+                      <input type="text" name="message" placeholder="Type Message ..." class="form-control">
                       <span class="input-group-btn">
                         <button type="button" class="btn btn-warning btn-flat">Send</button>
                       </span>
@@ -1026,7 +1026,7 @@
                 <div class="box-footer">
                   <form action="#" method="post">
                     <div class="input-group">
-                      <input type="text" name="message" placeholder="Type Message ..." class="form-control"/>
+                      <input type="text" name="message" placeholder="Type Message ..." class="form-control">
                       <span class="input-group-btn">
                         <button type="button" class="btn btn-danger btn-flat">Send</button>
                       </span>
@@ -1156,7 +1156,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Report panel usage
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Some information about this general settings option
@@ -1166,7 +1166,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Allow mail redirect
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Other sets of options are available
@@ -1176,7 +1176,7 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Expose author name in posts
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Allow the user to show his name in blog posts
@@ -1188,14 +1188,14 @@
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Show me as online
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>                
               </div><!-- /.form-group -->
 
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Turn off notifications
-                  <input type="checkbox" class="pull-right" />
+                  <input type="checkbox" class="pull-right">
                 </label>                
               </div><!-- /.form-group -->
 

--- a/starter.html
+++ b/starter.html
@@ -232,7 +232,7 @@ scratch. This page gets rid of all links and provides the needed markup only.
           <!-- search form (Optional) -->
           <form action="#" method="get" class="sidebar-form">
             <div class="input-group">
-              <input type="text" name="q" class="form-control" placeholder="Search..."/>
+              <input type="text" name="q" class="form-control" placeholder="Search...">
               <span class="input-group-btn">
                 <button type='submit' name='search' id='search-btn' class="btn btn-flat"><i class="fa fa-search"></i></button>
               </span>
@@ -339,7 +339,7 @@ scratch. This page gets rid of all links and provides the needed markup only.
               <div class="form-group">
                 <label class="control-sidebar-subheading">
                   Report panel usage
-                  <input type="checkbox" class="pull-right" checked />
+                  <input type="checkbox" class="pull-right" checked>
                 </label>
                 <p>
                   Some information about this general settings option


### PR DESCRIPTION
Input is a void element which can only have a start tag, end tags must not be specified.

http://www.w3.org/TR/html5/syntax.html#void-elements