### PR TITLE
Fixes error when installing with bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "AdminLTE",
+  "name": "admin-lte",
   "homepage": "http://almsaeedstudio.com",
   "authors": [
     "Abdullah Almsaeed <support@almsaeedstudio.com>"


### PR DESCRIPTION
When running `bower install admin-lte` the installation fails with the error that the name in the package's bower.json contains uppercase letters. This should fix that.