### PR TITLE
enable font awesome in form controls

### DIFF
--- a/build/less/forms.less
+++ b/build/less/forms.less
@@ -80,3 +80,19 @@
 .icheck > label {
   padding-left: 0;
 }
+
+/* support Font Awesome icons in form-control */
+.form-control-feedback.fa {
+    line-height: @input-height-base;
+}
+
+.input-lg + .form-control-feedback.fa,
+.input-group-lg + .form-control-feedback.fa,
+.form-group-lg .form-control + .form-control-feedback.fa {
+  line-height: @input-height-large;
+}
+.input-sm + .form-control-feedback.fa,
+.input-group-sm + .form-control-feedback.fa,
+.form-group-sm .form-control + .form-control-feedback.fa {
+  line-height: @input-height-small;
+}


### PR DESCRIPTION
the form controls are preconfigured to use glyhicons but lack the support for FA icons, see #479 