### PR TITLE
Fix bug in documentation

### DIFF
--- a/documentation/index.html
+++ b/documentation/index.html
@@ -1314,7 +1314,7 @@ AdminLTE/
         </div><!-- /.box-body -->
       </div><!-- /.box -->
       <pre class="prettyprint">
-&LT;div class="box box-default">
+&LT;div class="box box-default collapsed-box">
   &LT;div class="box-header with-border">
     &LT;h3 class="box-title">Expandable&LT;/h3>
     &LT;div class="box-tools pull-right">


### PR DESCRIPTION
Class  collapsed-box was missing for Expandable box example.