### PR TITLE
remove multiple selection height property

### DIFF
--- a/build/less/select2.less
+++ b/build/less/select2.less
@@ -76,7 +76,6 @@
   .select2-selection--multiple {
     border: 1px solid @gray;
     border-radius: @input-radius;
-    height: 34px;
     &:focus {
       border-color: @light-blue;
     }


### PR DESCRIPTION
Height property can be auto or removed. I prefer to remove. because there is no height property original file

![select2multiple](https://cloud.githubusercontent.com/assets/5148536/8980978/439c0c34-36bd-11e5-92ff-56b93b671652.png)

![select2multiple2](https://cloud.githubusercontent.com/assets/5148536/8981014/830bcc10-36bd-11e5-90d8-7e648f6daa04.png)