### PR TITLE
Sidebar autoclose on turbolinks fixed. close #718

### DIFF
--- a/dist/js/app.js
+++ b/dist/js/app.js
@@ -388,7 +388,7 @@ function _init() {
   $.AdminLTE.tree = function (menu) {
     var _this = this;
     var animationSpeed = $.AdminLTE.options.animationSpeed;
-    $(document).on('click', menu + ' li a', function (e) {
+    $(menu).on('click', 'li a', function (e) {
       //Get the clicked link and the next element
       var $this = $(this);
       var checkElement = $this.next();


### PR DESCRIPTION
It's a very simple yet effective fix which prevent events on document fire more than once when using Turbolinks or similar tools.

Fixes #718, #328 