### PR TITLE
Remove sidebar click handler, before assigning one

### DIFF
--- a/dist/js/app.js
+++ b/dist/js/app.js
@@ -388,7 +388,8 @@ function _init() {
   $.AdminLTE.tree = function (menu) {
     var _this = this;
     var animationSpeed = $.AdminLTE.options.animationSpeed;
-    $(document).on('click', menu + ' li a', function (e) {
+    $(document).off('click', menu + ' li a')
+               .on('click', menu + ' li a', function (e) {
       //Get the clicked link and the next element
       var $this = $(this);
       var checkElement = $this.next();


### PR DESCRIPTION
I would like to propose a small change in assigning a click handler for sidebar items. The current code doesn't work well with the Rails Turbolinks and jquery.turbolinks gem. It fires multiple times, like in #328 issue. Maybe I'm wrong here, but it seems the proposed code is one of the best practices for those kind of problem. 

I found a solution [here](http://www.gajotres.net/prevent-jquery-multiple-event-triggering/).