### PR TITLE
Fix user widget footer padding

### DIFF
--- a/build/less/social-widgets.less
+++ b/build/less/social-widgets.less
@@ -41,7 +41,7 @@
     }
   }
   .box-footer {
-    padding-top: 30px;
+    padding-top: 34px;
   }
 }
 


### PR DESCRIPTION
With the actual padding, footer sections separation borders overfill the user avatar.

Try with 4 sections descriptions to see the bug.