### PR TITLE
Do not use absolute position for .pull-right on sidebar

### DIFF
--- a/build/less/sidebar-mini.less
+++ b/build/less/sidebar-mini.less
@@ -133,9 +133,6 @@
 .sidebar-menu li > a {
   position: relative;
   > .pull-right {
-    position: absolute;
-    top: 50%;
-    right: 10px;
-    margin-top: -7px;
+    margin-top: 2px;
   }
 }


### PR DESCRIPTION
Fixes #740.