### PR TITLE
Improve tree click event handler

### DIFF
--- a/dist/js/app.js
+++ b/dist/js/app.js
@@ -388,7 +388,7 @@ function _init() {
   $.AdminLTE.tree = function (menu) {
     var _this = this;
     var animationSpeed = $.AdminLTE.options.animationSpeed;
-    $(menu).on('click', 'li a', function (e) {
+    $(document).on('click', menu + ' li a', function (e) {
       //Get the clicked link and the next element
       var $this = $(this);
       var checkElement = $this.next();


### PR DESCRIPTION
Click event is not currently firing under angularJS implmentation. This fixes it without any breaking changes to the current functionality.