### PR TITLE
Fix selector in header.less

### DIFF
--- a/build/less/header.less
+++ b/build/less/header.less
@@ -44,7 +44,7 @@
   .navbar-right {
     float: right;
     @media (max-width: @screen-sm-max) {
-      a {
+      a:not(.btn) {
         color: inherit;
         background: transparent;
       }


### PR DESCRIPTION
I'm not sure why the color inherit and background transparent are here but they are causing some problems for me. Mainly the fact that they also apply to buttons in the `.navbar-nav > .user-menu > .dropdown-menu` element. Is this the correct way to fix it?