### PR TITLE
Layout Boxed bug when resize page

### DIFF
--- a/dist/js/app.js
+++ b/dist/js/app.js
@@ -476,6 +476,11 @@ function _init() {
           _this._fixForContent(sidebar);
         }
       }
+      
+      // When resize the page format sidebar position and height
+      $(window).resize(function () {
+        _this._fix(sidebar);
+      });
     },
     //Open the control sidebar
     open: function (sidebar, slide) {
@@ -497,13 +502,9 @@ function _init() {
       }
     },
     _fix: function (sidebar) {
-      var _this = this;
       if ($("body").hasClass('layout-boxed')) {
         sidebar.css('position', 'absolute');
         sidebar.height($(".wrapper").height());
-        $(window).resize(function () {
-          _this._fix(sidebar);
-        });
       } else {
         sidebar.css({
           'position': 'fixed',


### PR DESCRIPTION
When you use layout-boxed much times it gives an error of jQuery, because the _fix function in $.AdminLTE.controlSidebar, delegate itself to the resize method of page when it's layout-boxed, so after some resizing it turn to like 2k calls of the same method.