### PR TITLE
remove external font reference from default shipped CSS; update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ Change log
 
 **For the most recent change log, visit the [releases page](https://github.com/almasaeed2010/AdminLTE/releases).** We will add a detailed release notes to each new release. 
 
+**v2.3.…:**
+- Users now must explicitly include Google fonts themselves
+
 **v2.3.1:**
 - Fix sidebar issue #676
 - Fix BootLint warnings and errors

--- a/build/less/AdminLTE.less
+++ b/build/less/AdminLTE.less
@@ -5,8 +5,6 @@
  *   License: Open source - MIT
  *           Please visit http://opensource.org/licenses/MIT for more information
 !*/
-//google fonts
-@import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic);
 //Bootstrap Variables & Mixins
 //The core bootstrap code have not been modified. These files
 //are included only for reference.

--- a/dist/css/AdminLTE.css
+++ b/dist/css/AdminLTE.css
@@ -1,4 +1,3 @@
-@import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic);
 /*!
  *   AdminLTE v2.3.3
  *   Author: Almsaeed Studio

--- a/dist/css/AdminLTE.min.css
+++ b/dist/css/AdminLTE.min.css
@@ -1,4 +1,4 @@
-@import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic);/*!
+/*!
  *   AdminLTE v2.3.3
  *   Author: Almsaeed Studio
  *	 Website: Almsaeed Studio <http://almsaeedstudio.com>

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -180,6 +180,10 @@ AdminLTE/
     <li><a href="http://jquery.com/" target="_blank">jQuery 1.11+</a></li>
     <li><a href="#plugins">All other plugins are listed below</a></li>
   </ul>
+  <p>Additionally, users are expected to provide the Google fonts, for
+   example by adding…</p>
+  <pre>@import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic);</pre>
+  <p>… to their CSS, or add their own fonts to use instead.</p>
 </section>
 
 


### PR DESCRIPTION
users are now expected to either add that line to their own CSS or
provide their own fonts, but on the upside, this makes it possible
to actually use AdminLTE as shipped in production environments

fixes https://github.com/almasaeed2010/AdminLTE/issues/744