### PR TITLE
Remove sidebar click handler, before assigning one. Fix sidebar autoclose bug.

### DIFF
--- a/dist/js/app.js
+++ b/dist/js/app.js
@@ -388,7 +388,8 @@ function _init() {
   $.AdminLTE.tree = function (menu) {
     var _this = this;
     var animationSpeed = $.AdminLTE.options.animationSpeed;
-    $(document).on('click', menu + ' li a', function (e) {
+    $(document).off('click', menu + ' li a')
+               .on('click', menu + ' li a', function (e) {
       //Get the clicked link and the next element
       var $this = $(this);
       var checkElement = $this.next();


### PR DESCRIPTION
I've closed #1001, because it has problems with dynamic elements. I'm pretty sure this one doesn't.