### PR TITLE
Follow tree menu parent url if provided

### DIFF
--- a/dist/js/app.js
+++ b/dist/js/app.js
@@ -394,6 +394,11 @@ function _init() {
         var $this = $(this);
         var checkElement = $this.next();
 
+        // If the link has an url, just follow it.
+        if ('#' !== $this.attr('href')) {
+          return;
+        }
+
         //Check if the next element is a menu and is visible
         if ((checkElement.is('.treeview-menu')) && (checkElement.is(':visible')) && (!$('body').hasClass('sidebar-collapse'))) {
           //Close the menu


### PR DESCRIPTION
## Subject

On some cases, we might want to no use tree view collapsing but keep a link on the parent menu item.

This make sense to follow the link if a real URL is provided (e.g. not `#`)
## Concrete example

Take this menu extract:

![image](https://cloud.githubusercontent.com/assets/1698357/16646365/ecd59610-4429-11e6-8a04-7452abb54dbc.png)

The sub-menu only appear when you go on a specific domain dashboard (in this case, `chevallier.fr`).

But the "Domains" parent item is a link to the domain list.

ATM, I can't go back to this list because this link is now a collapsing action.

This PR solve the issue.
