### PR TITLE
Fonts system with LESS variables

### DIFF
--- a/build/less/AdminLTE.less
+++ b/build/less/AdminLTE.less
@@ -5,8 +5,6 @@
  *   License: Open source - MIT
  *           Please visit http://opensource.org/licenses/MIT for more information
 !*/
-//google fonts
-@import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic);
 //Bootstrap Variables & Mixins
 //The core bootstrap code have not been modified. These files
 //are included only for reference.
@@ -14,8 +12,10 @@
 @import (reference) "../bootstrap-less/variables.less";
 //MISC
 //----
-@import "core.less";
 @import "variables.less";
+//google fonts
+.import-google-fonts();
+@import "core.less";
 @import "mixins.less";
 //COMPONENTS
 //-----------

--- a/build/less/core.less
+++ b/build/less/core.less
@@ -13,7 +13,7 @@ body {
 body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  .font-family();
   font-weight: 400;
   overflow-x: hidden;
   overflow-y: auto;
@@ -145,7 +145,7 @@ h6,
 .h4,
 .h5,
 .h6 {
-  font-family: 'Source Sans Pro', sans-serif;
+  .font-family();
 }
 
 /* General Links */

--- a/build/less/header.less
+++ b/build/less/header.less
@@ -115,7 +115,7 @@
     line-height: 50px;
     text-align: center;
     width: @sidebar-width;
-    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    .font-family();
     padding: 0 15px;
     font-weight: 300;
     overflow: hidden;

--- a/build/less/mixins.less
+++ b/build/less/mixins.less
@@ -313,3 +313,16 @@
     }
   }
 }
+
+//Font-Family mixin
+.font-family() when (@custom-font-name = '') {
+	font-family: '@{google-font-name}', @fonts;
+}
+.font-family() when not (@custom-font-name = '') {
+	font-family: '@{custom-font-name}', @fonts;
+}
+
+//Conditional Import mixin
+.import-google-fonts() when (@custom-font-name = '') {
+	@import url('@{google-font-import-url}');
+}

--- a/build/less/variables.less
+++ b/build/less/variables.less
@@ -1,6 +1,13 @@
 //AdminLTE 2 Variables.less
 //=========================
 
+//FONT
+//--------------------------------------------------------
+
+@google-font-import-url: "https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic";
+@google-font-name: "Source Sans Pro";
+@custom-font-name: "";
+@fonts: ~"'Helvetica Neue', Helvetica, Arial, sans-serif";
 //PATHS
 //--------------------------------------------------------
 

--- a/dist/css/AdminLTE.css
+++ b/dist/css/AdminLTE.css
@@ -1,4 +1,4 @@
-@import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic);
+@import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic');
 /*!
  *   AdminLTE v2.3.5
  *   Author: Almsaeed Studio
@@ -143,7 +143,7 @@ body.hold-transition .main-header .logo {
 }
 /* Content */
 .content {
-  min-height: 20px;
+  min-height: 250px;
   padding: 15px;
   margin-right: auto;
   margin-left: auto;
@@ -163,7 +163,7 @@ h6,
 .h4,
 .h5,
 .h6 {
-  font-family: 'Source Sans Pro', sans-serif;
+  font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 /* General Links */
 a {
@@ -295,7 +295,7 @@ a:focus {
   line-height: 50px;
   text-align: center;
   width: 230px;
-  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   padding: 0 15px;
   font-weight: 300;
   overflow: hidden;


### PR DESCRIPTION
### Features:

**Added these LESS variables:**
- @google-font-import-url: The url to import google-font from
- @google-font-name: The name of the google-font to use
- @custom-font-name: If filled with a value; building LESS will not use google-fonts, instead fonts will be provided with custom-font-name (If i don't want to use google fonts, and i want to set the font to Segoe UI, i fill this LESS variable and build CSS. If this variable is empty, LESS will use google-font variables)
- @fonts: Fallback fonts. (Default: 'Helvetica Neue', Helvetica, Arial, sans-serif)  

**Choose to use google fonts or other system fonts**
### Notes:
- I used .font-family() mixin (which i created) everywhere instead of font-family: CSS declaration. To use declared variables in every font-family possible. This includes; `h` tags (which did not contain fallback fonts by default), `logo` tag (which did not contain default google font -Source Sans Pro- by default). This way font-family is standardized. I hope, using different font-families in `logo` and `h` tags was not because of a bug in the past and was not intentional.  
- I changed order of some `@import`s in AdminLTE.less to declare LESS variables in variables.less and use them when outputing `@import url(google-font-import-url)`
