### PR TITLE
Fixed a typo

### DIFF
--- a/dist/js/app.js
+++ b/dist/js/app.js
@@ -294,7 +294,7 @@ function _init() {
           //Destroy if it exists
           $(".sidebar").slimScroll({destroy: true}).height("auto");
           //Add slimscroll
-          $(".sidebar").slimscroll({
+          $(".sidebar").slimScroll({
             height: ($(window).height() - $(".main-header").height()) + "px",
             color: "rgba(0,0,0,0.2)",
             size: "3px"


### PR DESCRIPTION
It works because it's an alias. But it might be removed without warning.

While I'm here, being able to deactivate the treeview on the sidebar would be super nice, or have it as an _opt-in_ using a CSS class like *sidebar-as-tree*.