### PR TITLE
Add option to control sidemenu's tree views.

### DIFF
--- a/dist/js/app.js
+++ b/dist/js/app.js
@@ -63,6 +63,8 @@ $.AdminLTE.options = {
   //choose to enable the plugin, make sure you load the script
   //before AdminLTE's app.js
   enableFastclick: false,
+  //Control Sidebar Tree views
+  enableControlTreeView: true,
   //Control Sidebar Options
   enableControlSidebar: true,
   controlSidebarOptions: {
@@ -160,7 +162,9 @@ $(function () {
   $.AdminLTE.layout.activate();
 
   //Enable sidebar tree view controls
-  $.AdminLTE.tree('.sidebar');
+  if (o.enableControlTreeView) {
+    $.AdminLTE.tree('.sidebar');
+  }
 
   //Enable control sidebar
   if (o.enableControlSidebar) {

--- a/documentation/build/include/adminlte-options.html
+++ b/documentation/build/include/adminlte-options.html
@@ -54,6 +54,8 @@
   //choose to enable the plugin, make sure you load the script
   //before AdminLTE's app.js
   enableFastclick: true,
+  //Control Sidebar Tree Views
+  enableControlTreeView: true,
   //Control Sidebar Options
   enableControlSidebar: true,
   controlSidebarOptions: {

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -358,6 +358,8 @@ AdminLTE/
   //choose to enable the plugin, make sure you load the script
   //before AdminLTE's app.js
   enableFastclick: true,
+  //Control Sidebar Tree Views
+  enableControlTreeView: true,
   //Control Sidebar Options
   enableControlSidebar: true,
   controlSidebarOptions: {


### PR DESCRIPTION
Add an option to control sidebar's tree views. I found this useful when you try to integrate the theme with React and add come custom effects/logic at the menu.