### PR TITLE
updated the image boxed-bg.jpg location to dist

### DIFF
--- a/build/less/variables.less
+++ b/build/less/variables.less
@@ -4,7 +4,7 @@
 //PATHS
 //--------------------------------------------------------
 
-@boxed-layout-bg-image-path: "../img/boxed-bg.jpg";
+@boxed-layout-bg-image-path: "../../dist/img/boxed-bg.jpg";
 
 //COLORS
 //--------------------------------------------------------


### PR DESCRIPTION
There is no any `img` directory  inside `build` directory which is causing an issue when we build using `webpack` and `less`. If there is another method to build could you suggest me and decline the pull request.

Signed-off-by: Pralhad Shrestha <pralhad.shrestha05@gmail.com>