### PR TITLE
Fixed jumping buttons with Bootstrap tooltip

### DIFF
--- a/dist/js/app.js
+++ b/dist/js/app.js
@@ -184,7 +184,8 @@ $(function () {
   //Activate Bootstrap tooltip
   if (o.enableBSToppltip) {
     $('body').tooltip({
-      selector: o.BSTooltipSelector
+      selector: o.BSTooltipSelector,
+      container: 'body'
     });
   }
 


### PR DESCRIPTION
This pull request fixes an issue where buttons that are part of a Bootstrap button group jump on mouseover when a Bootstrap tooltip is added to them.