### PR TITLE
Fixes #1235 text overflow while in collapsed sidebar-mini

### DIFF
--- a/build/less/sidebar-mini.less
+++ b/build/less/sidebar-mini.less
@@ -59,6 +59,7 @@
               position: absolute;
               width: @sidebar-width - 50;
               left: 50px;
+              white-space: normal;
             }
 
             //position the header & treeview menus


### PR DESCRIPTION
Adds the `white-space: normal` property to avoid text overflow in the submenu items while in collapsed sidebar-mini state.