### PR TITLE
fix name attribute in bower.json, fix #1397

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "AdminLTE",
+  "name": "admin-lte",
   "homepage": "http://almsaeedstudio.com",
   "authors": [
     "Abdullah Almsaeed <abdullah@almsaeedstudio.com>"


### PR DESCRIPTION
The package name cannot contain uppercase letters.
https://github.com/bower/spec/blob/master/json.md#name

See #1397