### PR TITLE
Fixed input focus in sidebar after resizing (fixed layout)

### DIFF
--- a/dist/js/app.js
+++ b/dist/js/app.js
@@ -297,6 +297,7 @@ function _init() {
       //Enable slimscroll for fixed layout
       if ($.AdminLTE.options.sidebarSlimScroll) {
         if (typeof $.fn.slimScroll != 'undefined') {
+          var focusedElement = $("input:focus", $(".sidebar"));
           //Destroy if it exists
           $(".sidebar").slimScroll({destroy: true}).height("auto");
           //Add slimscroll
@@ -305,6 +306,10 @@ function _init() {
             color: "rgba(0,0,0,0.2)",
             size: "3px"
           });
+          //Refocus input if it exists after slimscroll init
+          if(focusedElement[0]) {
+            focusedElement.focus();
+          }
         }
       }
     }


### PR DESCRIPTION
Highly related to this issue: https://github.com/almasaeed2010/AdminLTE/issues/427

On mobile when opening sidebar and focusing on an input (search bar in this case) the virtual keyboard will pop-up which will trigger the window resize (testable here: https://almsaeedstudio.com/themes/AdminLTE/pages/layout/fixed.html):

`  $(window, ".wrapper").resize(function () {
    _this.fix();
    _this.fixSidebar();
  });`

Slimscroll uses jQuery wrap and unwrap to add container to the slimscrollable content, this in hand removes the DOM and re-adds it which will cause the element to lose focus. So the virtual keyboard will pop up and then instantly disappear, making it impossible to type anything into search input. 

This code will check if input was focused in the sidebar prior to calling destroy and then init on the now resized sidebar. This is not optimal as it will cause a double refire, but it works. Possibly a more permanent solution is to add slimscroll only to the ul element containing the menu instead of the entire sidebar.