### PR TITLE
fix control sidebar top padding

### DIFF
--- a/build/less/control-sidebar.less
+++ b/build/less/control-sidebar.less
@@ -24,7 +24,7 @@
   padding-top: @navbar-height;
   z-index: 1010;
   // Fix position after header collapse
-  @media (max-width: @screen-sm) {
+  @media (max-width: @screen-xs-max) {
     padding-top: @navbar-height + 50;
   }
   // Tab panes


### PR DESCRIPTION
To see the the problem:
1. Go to https://adminlte.io/themes/AdminLTE/index2.html
2. Open the control sidebar
3. Set browser width to exactly 768px

Top padding adjustment media query was off by 1px. Window width 768px (iPad) would show the additional padding, when it should only show at < 768px.

This PR fixes that.