### PR TITLE
Composer installer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
   "name": "almasaeed2010/adminlte",
   "description": "AdminLTE - admin control panel and dashboard that's based on Bootstrap 3",
   "homepage": "https://adminlte.io/",
+  "type": "template",
   "keywords": [
     "css",
     "js",

--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,8 @@
   "license": "MIT",
   "support": {
     "issues": "https://github.com/almasaeed2010/AdminLTE/issues"
+  },
+  "require": {
+    "composer/installers": "1.*"
   }
 }


### PR DESCRIPTION
Introduces support for composer installer (see [here](https://getcomposer.org/doc/faqs/how-do-i-install-a-package-to-a-custom-path-for-my-framework.md)). With this feature PHP developers will be able to specify where they want AdminLTE installed by adding:

```
"extra": {
  "installer-paths": {
    "my/template/path/": ["type:template"]
  }
}
```
to their composer.json