### PR TITLE
change plugin name in documentation from Slim Scroll to jQuery slimScroll

### DIFF
--- a/documentation/index.html
+++ b/documentation/index.html
@@ -2029,7 +2029,7 @@
               <li><a href="http://jqueryui.com/" target="_blank">jQuery UI</a></li>
               <li><a href="http://anthonyterrien.com/knob/" target="_blank">jQuery Knob</a></li>
               <li><a href="http://jvectormap.com/" target="_blank">jVector Map</a></li>
-              <li><a href="http://rocha.la/jQuery-slimScroll/" target="_blank">Slim Scroll</a></li>
+              <li><a href="http://rocha.la/jQuery-slimScroll/" target="_blank">jQuery slimScroll</a></li>
               <li><a href="http://github.hubspot.com/pace/docs/welcome/" target="_blank">Pace</a></li>
             </ul>
           </div><!-- /.col -->


### PR DESCRIPTION
`slim scroll` (https://www.npmjs.com/package/slimscroll) is another library which is different from jQuery slim scroll, it may cause misunderstandings.