### PR TITLE
Update npmignore: don't ignore bower_components

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,2 @@
-bower_components/
 documentation/
 composer.json


### PR DESCRIPTION
Without them the npm package is crippled. It's hard to import `admin-lte` less files since many of them reference missing `bower_components`.

E.g. in a file `my_custom_styles.less` will line `@import "~admin-lte/build/less/AdminLTE";` fail on:

```
    Module build failed:

    // Import variables and mixins as a reference for separate plugins version
    @import (reference) "../../bower_components/bootstrap/less/mixins";
    ^
    Can't resolve '../../bower_components/bootstrap/less/mixins.less' in 'C:\z\my_project\node_modules\admin-lte\build\less'
          in C:\z\my_project\node_modules\admin-lte\build\less\bootstrap-social.less (line 11, column 0)
```