### PR TITLE
Fixed an issue where height becomes NaN when there is no main-header

### DIFF
--- a/build/js/Layout.js
+++ b/build/js/Layout.js
@@ -84,8 +84,9 @@
     $(Selector.layoutBoxed + ' > ' + Selector.wrapper).css('overflow', 'hidden');
 
     // Get window height and the wrapper height
-    var footerHeight  = $(Selector.mainFooter).outerHeight() || 0;
-    var neg           = $(Selector.mainHeader).outerHeight() + footerHeight;
+    var footerHeight = $(Selector.mainFooter).outerHeight() || 0;
+    var headerHeight  = $(Selector.mainHeader).outerHeight() || 0;
+    var neg           = headerHeight + footerHeight;
     var windowHeight  = $(window).height();
     var sidebarHeight = $(Selector.sidebar).height() || 0;
 


### PR DESCRIPTION
When .main-header is generated dynamically, height becomes undefined on onload.
NaN is assigned to min-height of .content-wrapper by undefined calculation.
I fixed the problem.