### PR TITLE
return the initialized editor

### DIFF
--- a/plugins/bootstrap-wysihtml5/bootstrap3-wysihtml5.all.js
+++ b/plugins/bootstrap-wysihtml5/bootstrap3-wysihtml5.all.js
@@ -14625,7 +14625,7 @@ function program17(depth0,data) {
         options = $.extend(true, {}, options);
         options.toolbar = this.toolbar[0];
         
-        this.initializeEditor(this.el[0], options);
+        return this.initializeEditor(this.el[0], options);
       },
 
 


### PR DESCRIPTION
I kept getting a 'wysihtml5Editor is undefined' error when using this code:

var wysihtml5Editor = $('#something').data('wysihtml5').editor;
wysihtml5Editor.composer.commands.exec('insertHTML','Some text to insert');

Then I went digging in the code and found that this : "this.editor =  this.createEditor(toolbarOpts);" on line 14613 does not return anything.
So when I add a return at the end of the createEditor function, it fixes my problem.