### PR TITLE
fix(skins): ISSUE 1925 - black layout, but font logo on the top is blue.

### DIFF
--- a/build/less/skins/skin-black-light.less
+++ b/build/less/skins/skin-black-light.less
@@ -41,7 +41,7 @@
         }
       }
     }
-    > .logo {
+    .logo {
       .logo-variant(#fff; #333);
       border-right: 1px solid @gray-lte;
       @media (max-width: @screen-header-collapse) {

--- a/build/less/skins/skin-black.less
+++ b/build/less/skins/skin-black.less
@@ -40,7 +40,7 @@
         }
       }
     }
-    > .logo {
+    .logo {
       .logo-variant(#fff; #333);
       border-right: 1px solid #eee;
       @media (max-width: @screen-header-collapse) {


### PR DESCRIPTION
#1926 - [ISSUE 1925 - black layout, but font logo on the top is blue.](https://github.com/almasaeed2010/AdminLTE/issues/1925)


I'm having the blue color problem when using ngx-admin-lte
the black skin looks like this:
black and black-light

```
> .logo {
      .logo-variant(#fff; #333);
      border-right: 1px solid @gray-lte;
      @media (max-width: @screen-header-collapse) {
        .logo-variant(#222; #fff);
        border-right: none;
      }
    }

```
and all others like this (without the '>' ):

```
    //Logo
    .logo {
      .logo-variant(darken(@<color>, 5%));
    }
```