### PR TITLE
[BUGFIX] #1944 Layout min-height consider footer-height [v3]

### DIFF
--- a/build/js/Layout.js
+++ b/build/js/Layout.js
@@ -60,7 +60,7 @@ const Layout = (($) => {
       }
       const max     = this._max(heights)
 
-      $(Selector.CONTENT).css('min-height', max - (heights.header))
+      $(Selector.CONTENT).css('min-height', max - heights.header - heights.footer)
       $(Selector.SIDEBAR).css('min-height', max - heights.header)
     }
 


### PR DESCRIPTION
Fix Layout content height to consider footer-height when setting min-height