### PR TITLE
Fix #1962 Problems with Timepicker in AdminLTE v3 (missing icons)

### DIFF
--- a/pages/forms/advanced.html
+++ b/pages/forms/advanced.html
@@ -989,7 +989,9 @@
 
     //Timepicker
     $('.timepicker').timepicker({
-      showInputs: false
+      showInputs: false,
+      upArrowStyle: 'fa fa-chevron-up',
+      downArrowStyle: 'fa fa-chevron-down'
     })
   })
 </script>


### PR DESCRIPTION
Fix #1962 missing icons (up and down) due to Bootstrap 4 dropped the Glyphicons icon font, using icons from Font Awesome instead (bootstrap-timepicker plugin's configuration).

<img width="184" alt="screen shot 2018-08-14 at 01 35 30" src="https://user-images.githubusercontent.com/6562562/44050829-5a59f36c-9f62-11e8-9ac8-ea3448653226.png">
