### PR TITLE
Add pi-hole's dashboard to implementations

### DIFF
--- a/documentation/index.html
+++ b/documentation/index.html
@@ -2099,6 +2099,7 @@
           <li><a href="https://github.com/avanzu/AdminThemeBundle" target="_blank">Symfony</a> by <a href="https://github.com/avanzu" target="_blank">Marc Bach</a></li>
           <li>Rails gems: <a href="https://github.com/nicolas-besnard/adminlte2-rails" target="_blank">adminlte2-rails</a> by <a href="https://github.com/nicolas-besnard" target="_blank">Nicolas Besnard</a> and <a href="https://github.com/racketlogger/lte-rails" target="_blank">lte-rails</a> (using AdminLTE sources) by <a href="https://github.com/racketlogger" target="_blank">Carlos at RacketLogger</a></li>
           <li><a href="https://github.com/misterGF/CoPilot" target="_blank">CoPilot (AdminLTE with Vue.js)</a> by<a href="https://github.com/misterGF" target="_blank">Gil Ferreira</a></li>
+          <li><a href="https://github.com/pi-hole/AdminLTE" target="_blank">pi-hole dashboard</a> by<a href="https://github.com/pi-hole" target="_blank">pi-hole</a></li>
         </ul>
 
         <p><b class="text-red">Note:</b> these implementations are not supported by Almsaeed Studio. However,


### PR DESCRIPTION
pi-hole's dashboard has been using AdminLTE for a long time, yet was not in this list. So I am adding it.