### PR TITLE
added Symfony 4 compatible AdminLTE bundle

### DIFF
--- a/documentation/build/include/implementations.html
+++ b/documentation/build/include/implementations.html
@@ -9,7 +9,7 @@
     <li><a href="https://github.com/yajra/laravel-admin-template" target="_blank">Laravel</a> by <a href="https://github.com/yajra" target="_blank">Arjay Angeles</a></li>
     <li><a href="https://github.com/acacha/adminlte-laravel" target="_blank">Laravel 5 package</a> by <a href="https://github.com/acacha" target="_blank">Sergi Tur Badenas</a></li>
     <li><a href="https://github.com/jeroennoten/Laravel-AdminLTE" target="_blank">Laravel-AdminLTE</a> by <a href="https://github.com/jeroennoten" target="_blank">Jeroen Noten</a></li>
-    <li><a href="https://github.com/avanzu/AdminThemeBundle" target="_blank">Symfony</a> by <a href="https://github.com/avanzu" target="_blank">Marc Bach</a></li>
+    <li><a href="https://github.com/avanzu/AdminThemeBundle" target="_blank">Symfony</a> by <a href="https://github.com/avanzu" target="_blank">Marc Bach</a> (or for <a href="https://github.com/kevinpapst/AdminLTEBundle" target="_blank">Symfony 4</a> by <a href="https://github.com/kevinpapst" target="_blank">Kevin Papst</a>)</li>
     <li>Rails gems: <a href="https://github.com/nicolas-besnard/adminlte2-rails" target="_blank">adminlte2-rails</a> by <a href="https://github.com/nicolas-besnard" target="_blank">Nicolas Besnard</a> and <a href="https://github.com/racketlogger/lte-rails" target="_blank">lte-rails</a> (using AdminLTE sources) by <a href="https://github.com/racketlogger" target="_blank">Carlos at RacketLogger</a></li>
     <li><a href="https://github.com/misterGF/CoPilot" target="_blank">CoPilot (AdminLTE with Vue.js)</a> by<a href="https://github.com/misterGF" target="_blank">Gil Ferreira</a></li>
   </ul>


### PR DESCRIPTION
This PR adds a link to https://adminlte.io/docs/2.4/implementations for a Symfony 4 compatible AdminLTE bundle.

The currently linked version has many flaws / does not work correct with the latest Symfony framework (version 4).

I started working on that bundle, as I desperately needed a solution one for my own project. Thought I share it with the community, as more and more people are upgrading to the latest framework version and need a solution for their theme.