### PR TITLE
fix($login-and-register): input border breaks when focus and with validation class

### DIFF
--- a/build/scss/_login_and_register.scss
+++ b/build/scss/_login_and_register.scss
@@ -38,10 +38,40 @@
   .input-group {
     .form-control {
       border-right: none;
+
+      &:focus {
+        box-shadow: none;
+        & ~ .input-group-append .input-group-text {
+          border-color: $input-focus-border-color;
+        }
+      }
+      
+      &.is-valid {
+        &:focus {
+          box-shadow: none;
+        }
+        & ~ .input-group-append .input-group-text {
+          border-color: $success;
+        }
+      }
+
+      &.is-invalid {
+        &:focus {
+          box-shadow: none;
+        }
+        & ~ .input-group-append .input-group-text {
+          border-color: $danger;
+        }
+      }
     }
     .input-group-text {
       color: #777;
       background-color: transparent;
+      border-left: none;
+      transition: $input-transition;
+      // Fix boostrap issue temporarily https://github.com/twbs/bootstrap/issues/25110
+      border-bottom-right-radius: $border-radius !important;
+      border-top-right-radius: $border-radius !important;
     }
   }
 }


### PR DESCRIPTION
# Screenshots

## Before

![qq 20181126175551](https://user-images.githubusercontent.com/18205362/49011599-cfa4f580-f1b1-11e8-970b-2c981a8166e8.png)
![qq 20181126175400](https://user-images.githubusercontent.com/18205362/49011595-cf0c5f00-f1b1-11e8-81a6-b2b564ca6ba9.png)
![qq 20181126175408](https://user-images.githubusercontent.com/18205362/49011597-cf0c5f00-f1b1-11e8-8ba5-7c49383d2ee6.png)

## After

![qq 20181126192558](https://user-images.githubusercontent.com/18205362/49011619-d9c6f400-f1b1-11e8-86c4-6a7fb0c8192c.png)
![qq 20181126175315](https://user-images.githubusercontent.com/18205362/49011616-d92e5d80-f1b1-11e8-8b42-428c01eea5d7.png)
![qq 20181126175332](https://user-images.githubusercontent.com/18205362/49011617-d9c6f400-f1b1-11e8-991d-d27f97ea6540.png)

# Details

- remove `box-shadow` of input `:focus`
- add border on `input-group-append` according to the status
- fix boostrap issue [#25110](https://github.com/twbs/bootstrap/issues/25110) temporarily by adding border-radius manually