### PR TITLE
Fix CONTENT height calculation by subtracting also footer height

### DIFF
--- a/dist/js/adminlte.js
+++ b/dist/js/adminlte.js
@@ -229,7 +229,7 @@ var Layout = function ($) {
       };
       var max = this._max(heights);
 
-      $(Selector.CONTENT).css('min-height', max - heights.header);
+      $(Selector.CONTENT).css('min-height', max - heights.header - heights.footer);
       $(Selector.SIDEBAR).css('min-height', max - heights.header);
     };
 


### PR DESCRIPTION
The CONTENT height was being calculated based only on the header height.
The subtraction of footers height was missing.
By adding it the content height calculation was fixed.