### PR TITLE
Calculate min-height of Selector.CONTENT by additionally reducing height of the footer.

### DIFF
--- a/build/js/Layout.js
+++ b/build/js/Layout.js
@@ -60,8 +60,8 @@ const Layout = (($) => {
       }
       const max     = this._max(heights)
 
-      $(Selector.CONTENT).css('min-height', max - (heights.header))
-      $(Selector.SIDEBAR).css('min-height', max - heights.header)
+      $(Selector.CONTENT).css('min-height', max - heights.header - heights.footer);
+      $(Selector.SIDEBAR).css('min-height', max - heights.header - heights.footer);
     }
 
     // Private


### PR DESCRIPTION
In order the footer to be displayed, the min-height of the layout need to consider the height of the footer.