### PR TITLE
feat(medtrack): add state module and local storage adapter (PR1)

### DIFF
--- a/src/js/medtrack/index.js
+++ b/src/js/medtrack/index.js
@@ -1,0 +1,33 @@
+﻿/* src/js/medtrack/index.js */
+import { initState } from "./state.js";
+import LocalAdapter from "./storage/local-adapter.js";
+
+const seed = {
+  _v: 1,
+  hospitals: [
+    { code: "H01", name: "Hospital A", stakeholders: 3, contacts: null },
+    { code: "H02", name: "Hospital B", stakeholders: 2, contacts: null }
+  ],
+  tasks: []
+};
+
+(async function bootstrap() {
+  await initState({ useAdapter: LocalAdapter, seed });
+  console.info("medtrack: initialized (local adapter)");
+  // visible badge to confirm medtrack loaded
+  if (typeof document !== "undefined") {
+    const el = document.createElement("div");
+    el.id = "medtrack-badge";
+    el.textContent = "MedTrack (state ok)";
+    el.style.position = "fixed";
+    el.style.right = "12px";
+    el.style.bottom = "12px";
+    el.style.zIndex = "9999";
+    el.style.background = "#007bff";
+    el.style.color = "#fff";
+    el.style.padding = "6px 10px";
+    el.style.borderRadius = "6px";
+    el.style.fontSize = "12px";
+    document.body.appendChild(el);
+  }
+})();

--- a/src/js/medtrack/state.js
+++ b/src/js/medtrack/state.js
@@ -1,0 +1,59 @@
+﻿/* src/js/medtrack/state.js */
+import LocalAdapter from "./storage/local-adapter.js";
+// import ApiAdapter from "./storage/api-adapter.js"; // for later
+
+let adapter = LocalAdapter;
+let _state = null;
+const subscribers = new Set();
+
+export async function initState({ useAdapter = null, seed = null } = {}) {
+  if (useAdapter) adapter = useAdapter;
+  const remote = await adapter.read();
+  if (remote) {
+    _state = remote;
+  } else if (seed) {
+    _state = seed;
+    await adapter.write(_state);
+  } else {
+    _state = {};
+    await adapter.write(_state);
+  }
+  publish();
+  return getState();
+}
+
+export function getState() {
+  return JSON.parse(JSON.stringify(_state));
+}
+
+export async function saveState() {
+  if (!_state) throw new Error("State not initialised");
+  await adapter.write(_state);
+}
+
+export async function mutate(mutatorFn) {
+  if (!_state) throw new Error("State not initialised");
+  const draft = JSON.parse(JSON.stringify(_state));
+  const result = await Promise.resolve().then(() => mutatorFn(draft));
+  _state = draft;
+  await saveState();
+  publish();
+  return result;
+}
+
+export function subscribe(fn) {
+  subscribers.add(fn);
+  try { fn(getState()); } catch(e){ console.error("subscriber initial error", e); }
+  return () => subscribers.delete(fn);
+}
+
+function publish() {
+  const snapshot = getState();
+  for (const fn of Array.from(subscribers)) {
+    try { fn(snapshot); } catch (e) { console.error("subscriber error", e); }
+  }
+}
+
+export function setAdapter(newAdapter) {
+  adapter = newAdapter;
+}

--- a/src/js/medtrack/storage/api-adapter.js
+++ b/src/js/medtrack/storage/api-adapter.js
@@ -1,0 +1,38 @@
+﻿/* src/js/medtrack/storage/api-adapter.js */
+const BASE = "/api/medtrack";
+
+export default {
+  async read() {
+    try {
+      const res = await fetch(`${BASE}/state`, { credentials: "same-origin" });
+      if (!res.ok) return null;
+      return res.json();
+    } catch (err) {
+      console.error("medtrack api read failed", err);
+      return null;
+    }
+  },
+
+  async write(state) {
+    try {
+      const res = await fetch(`${BASE}/state`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        credentials: "same-origin",
+        body: JSON.stringify(state)
+      });
+      return res.ok;
+    } catch (err) {
+      console.error("medtrack api write failed", err);
+      return false;
+    }
+  },
+
+  async clear() {
+    try {
+      await fetch(`${BASE}/state`, { method: "DELETE", credentials: "same-origin" });
+    } catch (err) {
+      console.error("medtrack api clear failed", err);
+    }
+  }
+};

--- a/src/js/medtrack/storage/local-adapter.js
+++ b/src/js/medtrack/storage/local-adapter.js
@@ -1,0 +1,29 @@
+﻿/* src/js/medtrack/storage/local-adapter.js */
+const STORAGE_KEY = "medtrack_v1";
+
+export default {
+  async read() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return null;
+      return JSON.parse(raw);
+    } catch (err) {
+      console.error("medtrack: failed to parse local state", err);
+      return null;
+    }
+  },
+
+  async write(state) {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+      return true;
+    } catch (err) {
+      console.error("medtrack: failed to write local state", err);
+      return false;
+    }
+  },
+
+  async clear() {
+    localStorage.removeItem(STORAGE_KEY);
+  }
+};

--- a/src/ts/adminlte.ts
+++ b/src/ts/adminlte.ts
@@ -52,3 +52,5 @@ export {
   PushMenu,
   initAccessibility
 }
+
+import "../js/medtrack/index.js";


### PR DESCRIPTION
## Summary
Add the MedTrack feature foundation: a state module and storage adapters. This PR prepares the project for a modular port of the existing SPA into AdminLTE by introducing a single source-of-truth state and a LocalStorage adapter, plus an API adapter stub for later backend integration.

## What this PR adds
- `src/js/medtrack/index.js` — medtrack bootstrap (initialises state + visible dev badge)
- `src/js/medtrack/state.js` — state module (init, getState, mutate, subscribe, setAdapter)
- `src/js/medtrack/storage/local-adapter.js` — LocalStorage adapter (read/write/clear)
- `src/js/medtrack/storage/api-adapter.js` — API adapter stub (read/write/clear)
- Import added to `src/ts/adminlte.ts` to bundle medtrack in the build.

## Why
- Decouples storage from UI so we can switch to a backend (`ApiAdapter`) later without refactoring views.
- Provides pub/sub so views re-render automatically when state changes.
- Small, reviewable PR to establish the MedTrack feature folder and CI-ready structure.

## How to test locally
1. `npm install`
2. `npm run build`
3. `npm start` and open the local demo site
4. Open DevTools -> Console and run:
   ```js
   localStorage.getItem('medtrack_v1')
