### PR TITLE
Remove code comments on TypeScript compilation process

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "root": true,
   "compilerOptions": {
+    "removeComments": true,
     "noFallthroughCasesInSwitch": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
Remove comments on the compilation process of `TypeScript` code. This only affects the generated `adminlte.js` file, as the minimized `adminlte.min.js` already handles this.
- Comments are useful only for maintenance, on source files, there's no benefit on having them on the compiled `adminlte.js` distribution file.
- This also reduces the compiled file sizes.