### PR TITLE
fix: early return from slideDown/slideUp if duration is less than 1

### DIFF
--- a/src/ts/util/index.ts
+++ b/src/ts/util/index.ts
@@ -48,6 +48,11 @@ const safePropertyAccess = (obj: Record<string, unknown>, property: string): unk
 
 /* SLIDE UP */
 const slideUp = (target: HTMLElement, duration = 500) => {
+  if (duration <= 1) {
+    target.style.display = 'none'
+    return
+  }
+
   target.style.transitionProperty = 'height, margin, padding'
   target.style.transitionDuration = `${duration}ms`
   target.style.boxSizing = 'border-box'
@@ -86,8 +91,8 @@ const slideDown = (target: HTMLElement, duration = 500) => {
 
   target.style.display = display
 
-  if (duration === 0) {
-    return;
+  if (duration <= 1) {
+    return
   }
 
   const height = target.offsetHeight


### PR DESCRIPTION
This PR adds an early return to the `slideDown` / `slideDown` function that skips the animation if the duration is less than (or equal to) 1. 

---

Currently, when the duration is zero, the second timeout runs BEFORE the first one (at least on Firefox), and doesn't properly clear the style attributes:

https://github.com/ColorlibHQ/AdminLTE/blob/5196a37407d9df1d1ac35d13c86e7bd1a5448282/src/ts/util/index.ts#L96-L112

---

This fixes a bug in the sidebar treeview, where this function is used with a duration of zero to instantly open entries when the page loads:

https://github.com/ColorlibHQ/AdminLTE/blob/5196a37407d9df1d1ac35d13c86e7bd1a5448282/src/ts/treeview.ts#L120

As an alternative fix, the duration parameter could be clamped to be greater than 1.