### PR TITLE
fix: consistent sidebar style

### DIFF
--- a/src/scss/_app-sidebar.scss
+++ b/src/scss/_app-sidebar.scss
@@ -106,31 +106,31 @@
 
   // Sidebar Menu. First level links
   .sidebar-menu > .nav-item {
-    &.menu-open {
-      .nav-link.active:not(:hover) {
-        --#{$lte-prefix}sidebar-menu-active-bg: transparent;
-      }
-    }
-
     // links
     > .nav-link {
-      &:active,
+      color: var(--#{$lte-prefix}sidebar-color);
+
+      &:hover,
       &:focus {
-        color: var(--#{$lte-prefix}sidebar-color);
+        color: var(--#{$lte-prefix}sidebar-hover-color);
+        background-color: var(--#{$lte-prefix}sidebar-hover-bg);
+      }
+
+      &.active {
+        color: var(--#{$lte-prefix}sidebar-menu-active-color);
+        background-color: var(--#{$lte-prefix}sidebar-menu-active-bg);
       }
     }
 
-    > .nav-link.active:not(:hover) {
-      color: var(--#{$lte-prefix}sidebar-menu-active-color);
-      background-color: var(--#{$lte-prefix}sidebar-menu-active-bg);
-    }
-
-    // Hover and active states
-    &.menu-open > .nav-link,
-    &:hover > .nav-link,
-    > .nav-link:focus  {
+    // Open state
+    &.menu-open > .nav-link {
       color: var(--#{$lte-prefix}sidebar-hover-color);
       background-color: var(--#{$lte-prefix}sidebar-hover-bg);
+
+      &.active {
+        color: var(--#{$lte-prefix}sidebar-menu-active-color);
+        background-color: var(--#{$lte-prefix}sidebar-menu-active-bg);
+      }
     }
 
     // First Level Submenu
@@ -162,21 +162,13 @@
         &:hover,
         &:focus {
           color: var(--#{$lte-prefix}sidebar-submenu-hover-color);
-          // background-color: var(--#{$lte-prefix}sidebar-submenu-hover-bg);
+          background-color: var(--#{$lte-prefix}sidebar-submenu-hover-bg);
         }
-      }
 
-      > .nav-link.active {
-        &,
-        &:hover,
-        &:focus {
+        &.active {
           color: var(--#{$lte-prefix}sidebar-submenu-active-color);
           background-color: var(--#{$lte-prefix}sidebar-submenu-active-bg);
         }
-      }
-
-      > .nav-link:hover {
-        background-color: var(--#{$lte-prefix}sidebar-submenu-hover-bg);
       }
     }
   }


### PR DESCRIPTION
Currently, nested links look different than top level links, which is especially noticeable when using custom sidebar colors. This PR makes the sidebar style more consistent, mostly by expanding the style of nested links onto top level links.

Here are a few of the inconsistencies in the old version fixed by this PR:
- Hovering over active top level links overrides the active colors with the hover colors. This does not happen with nested links.
- Focusing nested links does not apply the hover background color. This does happen with top level links.
- Open menus that are not active look weird, as they have the normal background but the hover text color. Because the SCSS rule explicitly sets the hover background color to transparent, it messes up the focus state (since that reuses the hover colors).